### PR TITLE
Add DNS-SD discovery client (browse + resolve)

### DIFF
--- a/agnostic-mdns/src/command.rs
+++ b/agnostic-mdns/src/command.rs
@@ -1,6 +1,10 @@
 //! Driver-task command/response channel types.
 
-use std::sync::{Arc, Mutex};
+use std::{
+  future::Future,
+  pin::Pin,
+  sync::{Arc, Mutex},
+};
 
 use mdns_proto::{QueryHandle, QuerySpec, ServiceHandle, ServiceSpec};
 
@@ -39,5 +43,10 @@ pub(crate) enum Command {
   },
   CancelQuery {
     handle: QueryHandle,
+  },
+  /// Spawn a detached discovery-lookup driver task from within the driver, so
+  /// it inherits the driver's runtime context (see [`crate::Endpoint::browse`]).
+  SpawnLookup {
+    task: Pin<Box<dyn Future<Output = ()> + Send>>,
   },
 }

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -332,6 +332,14 @@ impl Resolver {
     let host_key = fold(&host);
     let cached = self.host_addrs.get(&host_key);
     if let Some(b) = self.builders.get_mut(inst_key) {
+      // SRV retargeting the instance to a DIFFERENT host invalidates the old
+      // host's addresses — drop them before adopting the new host's, so a
+      // re-emit never yields an entry whose host is the new target but whose
+      // addresses still belong to the old one.
+      if b.host_key.as_deref() != Some(host_key.as_str()) {
+        b.ipv4.clear();
+        b.ipv6.clear();
+      }
       b.host = Some(host.clone());
       b.host_key = Some(host_key.clone());
       b.port = port;
@@ -696,7 +704,7 @@ impl Endpoint {
       resolve_timeout,
       unicast: param.unicast_response,
     };
-    self.spawn_task(driver.run());
+    self.spawn_lookup(driver.run())?;
 
     Ok(Lookup {
       queue,
@@ -1011,6 +1019,39 @@ mod tests {
     assert_eq!(launched, 4 * 2);
     // The 16 over-cap target hosts are counted so the partial view is observable.
     assert_eq!(r.dropped, 16);
+  }
+
+  #[test]
+  fn srv_retarget_drops_old_host_addresses() {
+    // An instance first resolves on host h1 (address A1). A later SRV retargets
+    // it to host h2; once h2's address arrives, the re-emitted entry must carry
+    // h2 and ONLY h2's address — never the stale h1 address.
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let h1 = Name::try_from_str("h1.local.").unwrap();
+    let h2 = Name::try_from_str("h2.local.").unwrap();
+    let k = fold(&inst);
+    let hk1 = fold(&h1);
+    let hk2 = fold(&h2);
+    r.on_ptr(inst);
+    r.on_srv(&k, h1, 8000);
+    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    let first = r.take_ready().expect("resolves on h1");
+    assert_eq!(first.host().as_str(), "h1.local.");
+    assert_eq!(first.ipv4_addresses(), [Ipv4Addr::new(10, 0, 0, 1)]);
+
+    // Retarget to h2; the old h1 address must be dropped immediately.
+    r.on_srv(&k, h2, 8000);
+    // h2's address arrives → re-emit with h2 and only the h2 address.
+    r.on_addr(&hk2, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)));
+    let second = r.take_ready().expect("re-emits on h2 address");
+    assert_eq!(second.host().as_str(), "h2.local.");
+    assert_eq!(
+      second.ipv4_addresses(),
+      [Ipv4Addr::new(10, 0, 0, 2)],
+      "stale h1 address must not survive the retarget"
+    );
   }
 
   #[test]

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -225,6 +225,10 @@ struct Builder {
   instance: Name,
   host: Option<Name>,
   host_key: Option<String>,
+  /// Whether an SRV record has been seen. Tracked separately from `port`
+  /// because `0` is a valid SRV port (the full `u16` range is parsed and the
+  /// registration API does not reject it), so it cannot double as a sentinel.
+  has_srv: bool,
   port: u16,
   ipv4: Vec<Ipv4Addr>,
   ipv6: Vec<Ipv6Addr>,
@@ -238,6 +242,7 @@ impl Builder {
       instance,
       host: None,
       host_key: None,
+      has_srv: false,
       port: 0,
       ipv4: Vec::new(),
       ipv6: Vec::new(),
@@ -246,9 +251,9 @@ impl Builder {
     }
   }
 
-  /// Complete once it has a port (SRV), TXT, and at least one address.
+  /// Complete once it has an SRV (host + port), TXT, and at least one address.
   fn complete(&self) -> bool {
-    self.port != 0 && self.txt.is_some() && !(self.ipv4.is_empty() && self.ipv6.is_empty())
+    self.has_srv && self.txt.is_some() && !(self.ipv4.is_empty() && self.ipv6.is_empty())
   }
 
   fn finalize(&self) -> Option<ServiceEntry> {
@@ -351,6 +356,7 @@ impl Resolver {
       // will arrive to trigger the re-emit, so without this the consumer keeps a
       // stale host/port.
       changed = host_changed || b.port != port;
+      b.has_srv = true;
       b.host = Some(host.clone());
       b.host_key = Some(host_key.clone());
       b.port = port;
@@ -632,7 +638,7 @@ impl LookupDriver {
       q.enqueue(entry);
       woke = true;
     }
-    q.dropped = self.resolver.dropped;
+    q.dropped = self.dropped_total();
     drop(q);
     if woke {
       let _ = self.doorbell.try_send(());
@@ -1092,6 +1098,25 @@ mod tests {
       [Ipv4Addr::new(10, 0, 0, 2)],
       "stale h1 address must not survive the retarget"
     );
+  }
+
+  #[test]
+  fn srv_port_zero_still_completes() {
+    // Port 0 is a valid SRV port; an instance advertising it must still surface
+    // once it has SRV (presence), TXT, and an address — `0` is not a "missing
+    // SRV" sentinel.
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k = fold(&inst);
+    let hk = fold(&host);
+    r.on_ptr(inst);
+    r.on_srv(&k, host, 0);
+    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    let e = r.take_ready().expect("an SRV with port 0 must still complete");
+    assert_eq!(e.port(), 0);
+    assert_eq!(e.ipv4_addresses(), [Ipv4Addr::new(10, 0, 0, 1)]);
   }
 
   #[test]

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -18,6 +18,17 @@
 //! and by [`QueryParam::with_max_entries`], and is cancelled by dropping the
 //! [`Lookup`].
 //!
+//! # Design
+//!
+//! Modeled on quinn's `ConnectionDriver`: a spawned [`LookupDriver`] task owns
+//! the browse/resolve sub-queries and the aggregation state machine, and pushes
+//! resolved entries into shared state ([`LookupQueue`]) that the [`Lookup`]
+//! handle drains — mirroring the [`crate::Query`] mailbox/doorbell split. Driving
+//! the aggregation in its own task (rather than only while the caller awaits
+//! [`Lookup::next`]) means the sub-query mailboxes are drained promptly, so a
+//! slow consumer cannot stall resolution; the shared queue stays bounded by
+//! coalescing repeated snapshots of an instance.
+//!
 //! Instance/host names that the [`Name`] type cannot represent faithfully — a
 //! label containing a `.` or a non-ASCII byte — are skipped rather than
 //! silently corrupted (`Name` is an ASCII, dot-separated, no-escaping type).
@@ -25,10 +36,11 @@
 use std::{
   collections::{HashMap, HashSet, VecDeque},
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
+  sync::{Arc, Mutex, MutexGuard},
   time::Duration,
 };
 
-use futures::{StreamExt, stream::SelectAll};
+use futures::{FutureExt, StreamExt, pin_mut, select_biased, stream::SelectAll};
 use mdns_proto::{
   Name, QuerySpec,
   wire::{ARecord, AaaaRecord, NameRef, PtrRecord, ResourceType, SrvRecord, TxtRecord},
@@ -256,14 +268,21 @@ struct HostAddrs {
   ipv6: Vec<Ipv6Addr>,
 }
 
-/// Pure browse/resolve aggregation state machine — no I/O. The [`Lookup`] feeds
-/// it parsed answers and launches the follow-up queries it requests.
+/// Pure browse/resolve aggregation state machine — no I/O. The [`LookupDriver`]
+/// feeds it parsed answers and launches the follow-up queries it requests.
 struct Resolver {
   builders: HashMap<String, Builder>,
   host_addrs: HashMap<String, HostAddrs>,
   hosts_queried: HashSet<String>,
   ready: VecDeque<ServiceEntry>,
+  /// Cap on distinct instances tracked.
   max_entries: usize,
+  /// Cap on distinct hosts A/AAAA-queried. Set equal to `max_entries`: honest
+  /// browsing has at most one host per instance, so this never bites a real
+  /// responder, but it bounds an instance that floods distinct SRV targets
+  /// (which would otherwise grow `hosts_queried`/`host_addrs` and the in-flight
+  /// A/AAAA sub-query set without limit).
+  max_hosts: usize,
   dropped: u64,
 }
 
@@ -275,6 +294,7 @@ impl Resolver {
       hosts_queried: HashSet::new(),
       ready: VecDeque::new(),
       max_entries,
+      max_hosts: max_entries,
       dropped: 0,
     }
   }
@@ -306,7 +326,8 @@ impl Resolver {
   }
 
   /// An instance's SRV: record host + port, adopt any addresses already learned
-  /// for that host, and request A/AAAA the first time we see the host.
+  /// for that host, and request A/AAAA the first time we see the host — subject
+  /// to the distinct-host cap, which bounds an SRV-target flood.
   fn on_srv(&mut self, inst_key: &str, host: Name, port: u16) -> Vec<Start> {
     let host_key = fold(&host);
     let cached = self.host_addrs.get(&host_key);
@@ -324,20 +345,26 @@ impl Resolver {
       }
     }
     self.try_emit(inst_key, false);
-    if self.hosts_queried.insert(host_key.clone()) {
-      vec![
-        Start {
-          name: host.clone(),
-          step: Step::A(host_key.clone()),
-        },
-        Start {
-          name: host,
-          step: Step::Aaaa(host_key),
-        },
-      ]
-    } else {
-      Vec::new()
+    if self.hosts_queried.contains(&host_key) {
+      return Vec::new(); // already querying this host
     }
+    if self.hosts_queried.len() >= self.max_hosts {
+      // SRV-target flood guard: refuse to query an unbounded set of hosts.
+      // Counted so the resulting partial view is observable via `dropped`.
+      self.dropped = self.dropped.saturating_add(1);
+      return Vec::new();
+    }
+    self.hosts_queried.insert(host_key.clone());
+    vec![
+      Start {
+        name: host.clone(),
+        step: Step::A(host_key.clone()),
+      },
+      Start {
+        name: host,
+        step: Step::Aaaa(host_key),
+      },
+    ]
   }
 
   fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
@@ -350,6 +377,9 @@ impl Resolver {
   /// An A/AAAA answer for a host: cache it (capped) and apply it to every
   /// instance whose SRV already pointed at that host. A newly-added address may
   /// re-emit an already-surfaced instance with the fuller address set.
+  ///
+  /// Only called for a host we actually launched A/AAAA queries for (a step key
+  /// from a query we started), so `host_addrs` stays bounded by `hosts_queried`.
   fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
     let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
     match addr {
@@ -402,83 +432,136 @@ impl Resolver {
   }
 }
 
-/// A running DNS-SD lookup.
-///
-/// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
-/// complete; it returns `None` once every query (browse + resolves) has timed
-/// out. Dropping the `Lookup` cancels all of its in-flight queries.
-pub struct Lookup {
+/// Bounded, instance-coalescing queue of resolved entries shared between the
+/// spawned [`LookupDriver`] (which fills it) and the [`Lookup`] handle (which
+/// drains it via [`Lookup::next`]). Mirrors the [`crate::Query`] mailbox.
+struct LookupQueue {
+  ready: VecDeque<ServiceEntry>,
+  /// Set once the driver task has finished (all sub-queries terminated, or the
+  /// handle was dropped). A drained-empty queue with `done` set is end-of-stream.
+  done: bool,
+  /// Snapshot of the resolver's drop counter, surfaced via [`Lookup::dropped`].
+  dropped: u64,
+}
+
+impl LookupQueue {
+  fn new() -> Self {
+    Self {
+      ready: VecDeque::new(),
+      done: false,
+      dropped: 0,
+    }
+  }
+
+  /// Enqueue a resolved entry, coalescing by instance so a slow consumer cannot
+  /// grow the queue past the live instance set: a newer snapshot for an instance
+  /// supersedes any still-pending one (matching the "later yield supersedes
+  /// earlier" contract on [`Lookup::next`]).
+  fn enqueue(&mut self, entry: ServiceEntry) {
+    if let Some(slot) = self
+      .ready
+      .iter_mut()
+      .find(|e| e.instance.as_str() == entry.instance.as_str())
+    {
+      *slot = entry;
+    } else {
+      self.ready.push_back(entry);
+    }
+  }
+}
+
+/// Lock the shared queue, recovering the guard if a previous holder panicked
+/// (the lock is never held across a fallible operation, so the data is sound).
+fn lock(q: &Mutex<LookupQueue>) -> MutexGuard<'_, LookupQueue> {
+  q.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Spawned task that owns the browse/resolve sub-queries and the [`Resolver`],
+/// feeding resolved entries into the shared [`LookupQueue`]. Quinn's
+/// `ConnectionDriver`, scoped to a single lookup.
+struct LookupDriver {
   endpoint: Endpoint,
   streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
   resolver: Resolver,
-  /// Follow-up queries discovered but not yet launched. Queued (rather than
-  /// launched inline) so that dropping the `next()` future mid-launch does not
-  /// lose them — they are retried on the next call.
-  pending_starts: VecDeque<Start>,
+  queue: Arc<Mutex<LookupQueue>>,
+  /// Capacity-1 wakeup the consumer parks on; rung after the queue changes.
+  doorbell: async_channel::Sender<()>,
+  /// Closes when the [`Lookup`] handle is dropped, which stops the task and
+  /// (by dropping the sub-query [`Query`] handles) cancels every sub-query.
+  cancel: async_channel::Receiver<()>,
   resolve_timeout: Duration,
   unicast: bool,
 }
 
-impl Lookup {
-  /// Wait for the next resolved service instance, or `None` when the lookup is
-  /// finished (all queries timed out).
-  ///
-  /// An instance may be yielded more than once as additional addresses resolve
-  /// (e.g. a late AAAA after the entry was first surfaced on its A address); a
-  /// later yield for the same [`ServiceEntry::instance_name`] supersedes the
-  /// earlier one. This method is cancellation-safe: dropping the future does
-  /// not lose queued follow-up queries.
-  pub async fn next(&mut self) -> Option<ServiceEntry> {
+impl LookupDriver {
+  async fn run(mut self) {
     loop {
-      if let Some(entry) = self.resolver.take_ready() {
-        return Some(entry);
+      // Wait for the next answer or for the handle to be dropped. The futures
+      // borrow disjoint fields; act on `self` only after the select resolves
+      // (mirrors the main driver loop's borrow discipline).
+      let tagged = {
+        let next = self.streams.next().fuse();
+        let stop = self.cancel.recv().fuse();
+        pin_mut!(next, stop);
+        select_biased! {
+          _ = stop => None,   // handle dropped → stop
+          t = next => t,      // Some(answer), or None when all sub-queries end
+        }
+      };
+      match tagged {
+        Some(t) => self.process(t).await,
+        None => break,
       }
-      // Launch queued follow-ups before polling for more answers. Peek-then-pop
-      // so a cancellation mid-launch leaves the start queued for a retry rather
-      // than dropping it (a benign double-start at worst).
-      if let Some(start) = self.pending_starts.front().cloned() {
-        self.launch(start).await;
-        self.pending_starts.pop_front();
-        continue;
-      }
-      let tagged = self.streams.next().await?;
-      self.process(tagged);
     }
+    // Signal end-of-stream and wake any parked consumer.
+    {
+      let mut q = lock(&self.queue);
+      q.done = true;
+      q.dropped = self.resolver.dropped;
+    }
+    let _ = self.doorbell.try_send(());
   }
 
-  /// Number of distinct instances dropped because the [`QueryParam`] cap was
-  /// reached. A non-zero value means the result set is a partial view.
-  pub fn dropped(&self) -> u64 {
-    self.resolver.dropped
+  /// Feed one answer to the resolver, launch any follow-up queries it requests,
+  /// then flush newly-resolved entries to the consumer.
+  async fn process(&mut self, tagged: Tagged) {
+    for start in self.feed(tagged) {
+      // Launch inline. If the handle was dropped mid-launch the `start_query`
+      // round-trip still completes promptly (the main driver replies regardless),
+      // and the next loop iteration's `cancel` arm stops the task.
+      self.launch(start).await;
+    }
+    self.flush();
   }
 
-  fn process(&mut self, tagged: Tagged) {
+  /// Decode `tagged`, feed the resolver, and return the follow-up queries.
+  fn feed(&mut self, tagged: Tagged) -> Vec<Start> {
     let answer = match tagged.event {
       QueryEvent::Answer(a) => a,
-      QueryEvent::Terminal(_) => return,
+      QueryEvent::Terminal(_) => return Vec::new(),
     };
-    let starts = match tagged.step {
+    match tagged.step {
       Step::Ptr => {
         if answer.rtype() != ResourceType::Ptr {
-          return;
+          return Vec::new();
         }
         match parse_name(answer.rdata_slice()) {
           Some(instance) => self.resolver.on_ptr(instance),
-          None => return,
+          None => Vec::new(),
         }
       }
       Step::Srv(inst_key) => {
         if answer.rtype() != ResourceType::Srv {
-          return;
+          return Vec::new();
         }
         match parse_srv(answer.rdata_slice()) {
           Some((host, port)) => self.resolver.on_srv(&inst_key, host, port),
-          None => return,
+          None => Vec::new(),
         }
       }
       Step::Txt(inst_key) => {
         if answer.rtype() != ResourceType::Txt {
-          return;
+          return Vec::new();
         }
         self
           .resolver
@@ -486,25 +569,37 @@ impl Lookup {
         Vec::new()
       }
       Step::A(host_key) => {
-        match ARecord::try_from_rdata(answer.rdata_slice()) {
-          Ok(r) if answer.rtype() == ResourceType::A => {
+        if let Ok(r) = ARecord::try_from_rdata(answer.rdata_slice()) {
+          if answer.rtype() == ResourceType::A {
             self.resolver.on_addr(&host_key, IpAddr::V4(r.addr()));
           }
-          _ => return,
         }
         Vec::new()
       }
       Step::Aaaa(host_key) => {
-        match AaaaRecord::try_from_rdata(answer.rdata_slice()) {
-          Ok(r) if answer.rtype() == ResourceType::Aaaa => {
+        if let Ok(r) = AaaaRecord::try_from_rdata(answer.rdata_slice()) {
+          if answer.rtype() == ResourceType::Aaaa {
             self.resolver.on_addr(&host_key, IpAddr::V6(r.addr()));
           }
-          _ => return,
         }
         Vec::new()
       }
-    };
-    self.pending_starts.extend(starts);
+    }
+  }
+
+  /// Move newly-resolved entries into the shared queue and wake the consumer.
+  fn flush(&mut self) {
+    let mut woke = false;
+    let mut q = lock(&self.queue);
+    while let Some(entry) = self.resolver.take_ready() {
+      q.enqueue(entry);
+      woke = true;
+    }
+    q.dropped = self.resolver.dropped;
+    drop(q);
+    if woke {
+      let _ = self.doorbell.try_send(());
+    }
   }
 
   /// Start a resolve sub-query and fold its answers into the merged stream.
@@ -519,6 +614,59 @@ impl Lookup {
   }
 }
 
+/// A running DNS-SD lookup.
+///
+/// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
+/// complete; it returns `None` once every query (browse + resolves) has timed
+/// out. Resolution is driven by a spawned [`LookupDriver`] task, so it proceeds
+/// even between calls to `next`. Dropping the `Lookup` stops that task and
+/// cancels all of its in-flight queries.
+pub struct Lookup {
+  queue: Arc<Mutex<LookupQueue>>,
+  /// Capacity-1 wakeup the driver rings after filling the queue.
+  doorbell: async_channel::Receiver<()>,
+  /// Held only so dropping the `Lookup` closes the driver's `cancel` channel.
+  _cancel: async_channel::Sender<()>,
+}
+
+impl Lookup {
+  /// Wait for the next resolved service instance, or `None` when the lookup is
+  /// finished (all queries timed out).
+  ///
+  /// An instance may be yielded more than once as additional addresses resolve
+  /// (e.g. a late AAAA after the entry was first surfaced on its A address); a
+  /// later yield for the same [`ServiceEntry::instance_name`] supersedes the
+  /// earlier one. Single-consumer: takes `&mut self`, so there is at most one
+  /// in-flight `next()` per `Lookup`, matching the single-waiter doorbell.
+  pub async fn next(&mut self) -> Option<ServiceEntry> {
+    loop {
+      {
+        let mut q = lock(&self.queue);
+        if let Some(entry) = q.ready.pop_front() {
+          return Some(entry);
+        }
+        if q.done {
+          return None;
+        }
+      }
+      // Nothing ready: park until the driver rings. A closed doorbell means the
+      // driver task exited — do one final drain (entries or the `done` flag it
+      // set just before exiting are already visible under the lock).
+      if self.doorbell.recv().await.is_err() {
+        return lock(&self.queue).ready.pop_front();
+      }
+    }
+  }
+
+  /// Number of discoveries dropped because a [`QueryParam`] cap was reached —
+  /// either the distinct-instance cap ([`QueryParam::with_max_entries`]) or the
+  /// distinct-host cap that bounds an SRV-target flood. A non-zero value means
+  /// the result set is a partial view.
+  pub fn dropped(&self) -> u64 {
+    lock(&self.queue).dropped
+  }
+}
+
 impl Endpoint {
   /// Browse for instances of a DNS-SD service type, resolving each into a
   /// [`ServiceEntry`]. See [`Lookup`] and [`QueryParam`].
@@ -527,16 +675,33 @@ impl Endpoint {
     let ptr_spec = QuerySpec::new(param.service, ResourceType::Ptr)
       .with_timeout(param.timeout)
       .with_unicast_response(param.unicast_response);
+    // Start the browse query up front so a start failure surfaces synchronously
+    // to the caller rather than vanishing inside the spawned task.
     let ptr_query = self.start_query(ptr_spec).await?;
+
     let mut streams = SelectAll::new();
     streams.push(tagged_stream(ptr_query, Step::Ptr));
-    Ok(Lookup {
+
+    let queue = Arc::new(Mutex::new(LookupQueue::new()));
+    let (doorbell_tx, doorbell_rx) = async_channel::bounded(1);
+    let (cancel_tx, cancel_rx) = async_channel::bounded(1);
+
+    let driver = LookupDriver {
       endpoint: self.clone(),
       streams,
       resolver: Resolver::new(param.max_entries),
-      pending_starts: VecDeque::new(),
+      queue: Arc::clone(&queue),
+      doorbell: doorbell_tx,
+      cancel: cancel_rx,
       resolve_timeout,
       unicast: param.unicast_response,
+    };
+    self.spawn_task(driver.run());
+
+    Ok(Lookup {
+      queue,
+      doorbell: doorbell_rx,
+      _cancel: cancel_tx,
     })
   }
 
@@ -825,5 +990,52 @@ mod tests {
       last.expect("at least one emit").ipv4_addresses().len(),
       MAX_ADDRS_PER_HOST
     );
+  }
+
+  #[test]
+  fn srv_target_flood_is_capped() {
+    // One instance whose SRV target host changes on every answer (a hostile or
+    // pathological responder) must not grow the host-query set without bound.
+    let mut r = Resolver::new(4); // max_hosts == max_entries == 4
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let k = fold(&inst);
+    r.on_ptr(inst);
+    let mut launched = 0usize;
+    for i in 0..20u16 {
+      let host = Name::try_from_str(&format!("h{i}.local.")).unwrap();
+      launched += r.on_srv(&k, host, 8000 + i).len();
+    }
+    // At most max_hosts distinct hosts get A+AAAA launches (2 starts each).
+    assert_eq!(r.hosts_queried.len(), 4);
+    assert_eq!(r.host_addrs.len(), 0, "no addresses arrived yet");
+    assert_eq!(launched, 4 * 2);
+    // The 16 over-cap target hosts are counted so the partial view is observable.
+    assert_eq!(r.dropped, 16);
+  }
+
+  #[test]
+  fn srv_txt_mutation_after_emit_stays_bounded() {
+    // After an instance is surfaced, further SRV/TXT answers (new target hosts,
+    // changed metadata) must not grow the host-query set past the cap or panic.
+    let mut r = Resolver::new(2); // max_hosts == 2
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let h1 = Name::try_from_str("h1.local.").unwrap();
+    let k = fold(&inst);
+    let hk1 = fold(&h1);
+    r.on_ptr(inst);
+    r.on_srv(&k, h1, 8000);
+    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    assert!(r.take_ready().is_some(), "instance completes on h1");
+
+    // SRV now mutates to a flood of new target hosts, and TXT keeps changing.
+    for i in 0..10u16 {
+      let h = Name::try_from_str(&format!("m{i}.local.")).unwrap();
+      r.on_srv(&k, h, 9000 + i);
+      r.on_txt(&k, vec![format!("v={i}").into_bytes()]);
+    }
+    // h1 took one host slot; at most one more (cap 2) is ever queried.
+    assert!(r.hosts_queried.len() <= 2, "host set stays bounded");
+    assert!(r.host_addrs.len() <= 2, "host cache stays bounded");
   }
 }

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -46,7 +46,11 @@ use mdns_proto::{
   wire::{ARecord, AaaaRecord, NameRef, PtrRecord, ResourceType, SrvRecord, TxtRecord},
 };
 
-use crate::{Endpoint, QueryEvent, error::StartQueryError, query::Query};
+use crate::{
+  Endpoint, QueryEvent,
+  error::StartQueryError,
+  query::{DroppedHandle, Query},
+};
 
 /// Default cap on the number of distinct instances a [`Lookup`] tracks, so a
 /// chatty or hostile responder flooding PTR answers cannot grow the builder map
@@ -383,10 +387,16 @@ impl Resolver {
   }
 
   fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
+    let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
+      // A TXT change to an already-surfaced instance must re-emit so the
+      // consumer sees the new metadata; a duplicate TXT must not (no spurious
+      // re-emit). First TXT flips this from `None`, driving the first emit once
+      // the instance is otherwise complete.
+      changed = b.txt.as_deref() != Some(segs.as_slice());
       b.txt = Some(segs);
     }
-    self.try_emit(inst_key, false);
+    self.try_emit(inst_key, changed);
   }
 
   /// An A/AAAA answer for a host: cache it (capped) and apply it to every
@@ -498,6 +508,11 @@ struct LookupDriver {
   endpoint: Endpoint,
   streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
   resolver: Resolver,
+  /// Drop counter of the browse (PTR) query. Surplus instances evicted by the
+  /// PTR query's bounded answer pool before [`Resolver::on_ptr`] sees them are
+  /// counted here rather than in `resolver.dropped`; folding both into
+  /// [`Lookup::dropped`] keeps the partial-view signal complete.
+  ptr_drops: DroppedHandle,
   queue: Arc<Mutex<LookupQueue>>,
   /// Capacity-1 wakeup the consumer parks on; rung after the queue changes.
   doorbell: async_channel::Sender<()>,
@@ -532,7 +547,7 @@ impl LookupDriver {
     {
       let mut q = lock(&self.queue);
       q.done = true;
-      q.dropped = self.resolver.dropped;
+      q.dropped = self.dropped_total();
     }
     let _ = self.doorbell.try_send(());
   }
@@ -600,6 +615,13 @@ impl LookupDriver {
         Vec::new()
       }
     }
+  }
+
+  /// Total observable drops surfaced via [`Lookup::dropped`]: instances refused
+  /// by the resolver caps plus surplus PTR answers the browse query's bounded
+  /// answer pool evicted before the resolver could see them (disjoint counts).
+  fn dropped_total(&self) -> u64 {
+    self.resolver.dropped.saturating_add(self.ptr_drops.get())
   }
 
   /// Move newly-resolved entries into the shared queue and wake the consumer.
@@ -673,10 +695,11 @@ impl Lookup {
     }
   }
 
-  /// Number of discoveries dropped because a [`QueryParam`] cap was reached —
-  /// either the distinct-instance cap ([`QueryParam::with_max_entries`]) or the
-  /// distinct-host cap that bounds an SRV-target flood. A non-zero value means
-  /// the result set is a partial view.
+  /// Number of discoveries dropped because a bound was reached: the
+  /// distinct-instance cap ([`QueryParam::with_max_entries`]), the distinct-host
+  /// cap that bounds an SRV-target flood, or surplus PTR answers evicted by the
+  /// browse query's bounded answer pool before they could be tracked. A non-zero
+  /// value means the result set is a partial view.
   pub fn dropped(&self) -> u64 {
     lock(&self.queue).dropped
   }
@@ -699,6 +722,9 @@ impl Endpoint {
     // Start the browse query up front so a start failure surfaces synchronously
     // to the caller rather than vanishing inside the spawned task.
     let ptr_query = self.start_query(ptr_spec).await?;
+    // Capture the browse query's drop counter before it is moved into the
+    // merged stream, so the driver can fold its evictions into `Lookup::dropped`.
+    let ptr_drops = ptr_query.dropped_handle();
 
     let mut streams = SelectAll::new();
     streams.push(tagged_stream(ptr_query, Step::Ptr));
@@ -711,6 +737,7 @@ impl Endpoint {
       endpoint: self.clone(),
       streams,
       resolver: Resolver::new(param.max_entries),
+      ptr_drops,
       queue: Arc::clone(&queue),
       doorbell: doorbell_tx,
       cancel: cancel_rx,
@@ -1065,6 +1092,31 @@ mod tests {
       [Ipv4Addr::new(10, 0, 0, 2)],
       "stale h1 address must not survive the retarget"
     );
+  }
+
+  #[test]
+  fn txt_change_after_emit_reemits() {
+    // A TXT update after the instance was surfaced must re-emit with the new
+    // metadata (a responder may refresh TXT while the lookup is still running);
+    // a duplicate TXT must not.
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k = fold(&inst);
+    let hk = fold(&host);
+    r.on_ptr(inst);
+    r.on_srv(&k, host, 7000);
+    r.on_txt(&k, vec![b"v=1".to_vec()]);
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    let first = r.take_ready().expect("first emit");
+    assert_eq!(first.txt(), [b"v=1".to_vec()]);
+    // Changed TXT → re-emit with the new metadata.
+    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    let second = r.take_ready().expect("re-emit on TXT change");
+    assert_eq!(second.txt(), [b"v=2".to_vec()]);
+    // Duplicate TXT → no re-emit.
+    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    assert!(r.take_ready().is_none(), "duplicate TXT must not re-emit");
   }
 
   #[test]

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -12,11 +12,15 @@
 //!    reachable addresses.
 //!
 //! An instance is surfaced as a [`ServiceEntry`] once it has a port (SRV), TXT
-//! data, and at least one address — matching the completeness rule of the
-//! original client. Each step is a real [`crate::Query`], so retransmission,
-//! caching, and TTL handling are inherited from the proto/driver layers; the
-//! whole lookup is bounded by the per-query timeouts and is cancelled by
-//! dropping the [`Lookup`].
+//! data, and at least one address. Each step is a real [`crate::Query`], so
+//! retransmission, caching, and TTL handling are inherited from the
+//! proto/driver layers; the whole lookup is bounded by the per-query timeouts
+//! and by [`QueryParam::with_max_entries`], and is cancelled by dropping the
+//! [`Lookup`].
+//!
+//! Instance/host names that the [`Name`] type cannot represent faithfully — a
+//! label containing a `.` or a non-ASCII byte — are skipped rather than
+//! silently corrupted (`Name` is an ASCII, dot-separated, no-escaping type).
 
 use std::{
   collections::{HashMap, HashSet, VecDeque},
@@ -31,6 +35,11 @@ use mdns_proto::{
 };
 
 use crate::{Endpoint, QueryEvent, error::StartQueryError, query::Query};
+
+/// Default cap on the number of distinct instances a [`Lookup`] tracks, so a
+/// chatty or hostile responder flooding PTR answers cannot grow the builder map
+/// or the in-flight sub-query set without bound.
+pub const DEFAULT_MAX_ENTRIES: usize = 64;
 
 /// A resolved DNS-SD service instance.
 ///
@@ -48,7 +57,7 @@ pub struct ServiceEntry {
 
 impl ServiceEntry {
   /// The fully-qualified service instance name (the PTR target), e.g.
-  /// `My Printer._ipp._tcp.local.`.
+  /// `myprinter._ipp._tcp.local.`.
   #[inline]
   pub fn instance_name(&self) -> &Name {
     &self.instance
@@ -104,6 +113,7 @@ pub struct QueryParam {
   timeout: Duration,
   resolve_timeout: Option<Duration>,
   unicast_response: bool,
+  max_entries: usize,
 }
 
 impl QueryParam {
@@ -115,6 +125,7 @@ impl QueryParam {
       timeout: Duration::from_secs(1),
       resolve_timeout: None,
       unicast_response: false,
+      max_entries: DEFAULT_MAX_ENTRIES,
     }
   }
 
@@ -140,6 +151,15 @@ impl QueryParam {
     self.unicast_response = unicast;
     self
   }
+
+  /// Cap on the number of distinct instances tracked; instances discovered
+  /// beyond it are dropped (counted by [`Lookup::dropped`]). Defaults to
+  /// [`DEFAULT_MAX_ENTRIES`]. A value of `0` is treated as `1`.
+  #[must_use]
+  pub const fn with_max_entries(mut self, max: usize) -> Self {
+    self.max_entries = if max == 0 { 1 } else { max };
+    self
+  }
 }
 
 /// Which resolve step an answer belongs to. The string is the case-folded key
@@ -157,6 +177,25 @@ enum Step {
 struct Tagged {
   step: Step,
   event: QueryEvent,
+}
+
+/// A follow-up query the driver should launch as a result of feeding the
+/// [`Resolver`] an answer.
+struct Start {
+  name: Name,
+  step: Step,
+}
+
+impl Start {
+  const fn qtype(&self) -> ResourceType {
+    match self.step {
+      Step::Srv(_) => ResourceType::Srv,
+      Step::Txt(_) => ResourceType::Txt,
+      Step::A(_) => ResourceType::A,
+      Step::Aaaa(_) => ResourceType::Aaaa,
+      Step::Ptr => ResourceType::Ptr,
+    }
+  }
 }
 
 /// In-progress aggregation of one service instance.
@@ -202,146 +241,151 @@ impl Builder {
   }
 }
 
-/// A running DNS-SD lookup.
-///
-/// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
-/// complete; it returns `None` once every query (browse + resolves) has timed
-/// out. Dropping the `Lookup` cancels all of its in-flight queries.
-pub struct Lookup {
-  endpoint: Endpoint,
-  streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
-  builders: HashMap<String, Builder>,
-  hosts_queried: HashSet<String>,
-  ready: VecDeque<ServiceEntry>,
-  resolve_timeout: Duration,
-  unicast: bool,
+/// Addresses already learned for a host, so a later instance whose SRV resolves
+/// to the same host picks them up even though the A/AAAA answer has come and
+/// gone (the shared-host, SRV-after-A ordering).
+#[derive(Default)]
+struct HostAddrs {
+  ipv4: Vec<Ipv4Addr>,
+  ipv6: Vec<Ipv6Addr>,
 }
 
-impl Lookup {
-  /// Wait for the next resolved service instance, or `None` when the lookup is
-  /// finished (all queries timed out).
-  pub async fn next(&mut self) -> Option<ServiceEntry> {
-    loop {
-      if let Some(entry) = self.ready.pop_front() {
-        return Some(entry);
-      }
-      let tagged = self.streams.next().await?;
-      self.process(tagged).await;
+/// Pure browse/resolve aggregation state machine — no I/O. The [`Lookup`] feeds
+/// it parsed answers and launches the follow-up queries it requests.
+struct Resolver {
+  builders: HashMap<String, Builder>,
+  host_addrs: HashMap<String, HostAddrs>,
+  hosts_queried: HashSet<String>,
+  ready: VecDeque<ServiceEntry>,
+  max_entries: usize,
+  dropped: u64,
+}
+
+impl Resolver {
+  fn new(max_entries: usize) -> Self {
+    Self {
+      builders: HashMap::new(),
+      host_addrs: HashMap::new(),
+      hosts_queried: HashSet::new(),
+      ready: VecDeque::new(),
+      max_entries,
+      dropped: 0,
     }
   }
 
-  async fn process(&mut self, tagged: Tagged) {
-    let answer = match tagged.event {
-      QueryEvent::Answer(a) => a,
-      QueryEvent::Terminal(_) => return,
-    };
-    match tagged.step {
-      Step::Ptr => {
-        if answer.rtype() != ResourceType::Ptr {
-          return;
-        }
-        let Some(instance) = parse_name(answer.rdata_slice()) else {
-          return;
-        };
-        let key = fold(&instance);
-        if self.builders.contains_key(&key) {
-          return; // already discovered this instance
-        }
-        self
-          .builders
-          .insert(key.clone(), Builder::new(instance.clone()));
-        self
-          .start(instance.clone(), ResourceType::Srv, Step::Srv(key.clone()))
-          .await;
-        self
-          .start(instance, ResourceType::Txt, Step::Txt(key))
-          .await;
-      }
-      Step::Srv(inst_key) => {
-        if answer.rtype() != ResourceType::Srv {
-          return;
-        }
-        let Some((host, port)) = parse_srv(answer.rdata_slice()) else {
-          return;
-        };
-        let host_key = fold(&host);
-        if let Some(b) = self.builders.get_mut(&inst_key) {
-          b.host = Some(host.clone());
-          b.host_key = Some(host_key.clone());
-          b.port = port;
-        }
-        if self.hosts_queried.insert(host_key.clone()) {
-          self
-            .start(host.clone(), ResourceType::A, Step::A(host_key.clone()))
-            .await;
-          self
-            .start(host, ResourceType::Aaaa, Step::Aaaa(host_key))
-            .await;
-        }
-        self.maybe_emit(&inst_key);
-      }
-      Step::Txt(inst_key) => {
-        if answer.rtype() != ResourceType::Txt {
-          return;
-        }
-        let segs = parse_txt(answer.rdata_slice());
-        if let Some(b) = self.builders.get_mut(&inst_key) {
-          b.txt = Some(segs);
-        }
-        self.maybe_emit(&inst_key);
-      }
-      Step::A(host_key) => {
-        if answer.rtype() != ResourceType::A {
-          return;
-        }
-        let Some(addr) = ARecord::try_from_rdata(answer.rdata_slice())
-          .ok()
-          .map(|r| r.addr())
-        else {
-          return;
-        };
-        for inst_key in self.builders_for_host(&host_key) {
-          if let Some(b) = self.builders.get_mut(&inst_key) {
-            if !b.ipv4.contains(&addr) {
-              b.ipv4.push(addr);
-            }
-          }
-          self.maybe_emit(&inst_key);
-        }
-      }
-      Step::Aaaa(host_key) => {
-        if answer.rtype() != ResourceType::Aaaa {
-          return;
-        }
-        let Some(addr) = AaaaRecord::try_from_rdata(answer.rdata_slice())
-          .ok()
-          .map(|r| r.addr())
-        else {
-          return;
-        };
-        for inst_key in self.builders_for_host(&host_key) {
-          if let Some(b) = self.builders.get_mut(&inst_key) {
-            if !b.ipv6.contains(&addr) {
-              b.ipv6.push(addr);
-            }
-          }
-          self.maybe_emit(&inst_key);
-        }
-      }
+  /// A newly discovered instance: register it (subject to the cap) and request
+  /// its SRV + TXT resolves.
+  fn on_ptr(&mut self, instance: Name) -> Vec<Start> {
+    let key = fold(&instance);
+    if self.builders.contains_key(&key) {
+      return Vec::new(); // already discovered
     }
-  }
-
-  /// Instance keys whose SRV target host matches `host_key`.
-  fn builders_for_host(&self, host_key: &str) -> Vec<String> {
+    if self.builders.len() >= self.max_entries {
+      self.dropped = self.dropped.saturating_add(1);
+      return Vec::new();
+    }
     self
+      .builders
+      .insert(key.clone(), Builder::new(instance.clone()));
+    vec![
+      Start {
+        name: instance.clone(),
+        step: Step::Srv(key.clone()),
+      },
+      Start {
+        name: instance,
+        step: Step::Txt(key),
+      },
+    ]
+  }
+
+  /// An instance's SRV: record host + port, adopt any addresses already learned
+  /// for that host, and request A/AAAA the first time we see the host.
+  fn on_srv(&mut self, inst_key: &str, host: Name, port: u16) -> Vec<Start> {
+    let host_key = fold(&host);
+    let cached = self.host_addrs.get(&host_key);
+    if let Some(b) = self.builders.get_mut(inst_key) {
+      b.host = Some(host.clone());
+      b.host_key = Some(host_key.clone());
+      b.port = port;
+      if let Some(addrs) = cached {
+        for &a in &addrs.ipv4 {
+          if !b.ipv4.contains(&a) {
+            b.ipv4.push(a);
+          }
+        }
+        for &a in &addrs.ipv6 {
+          if !b.ipv6.contains(&a) {
+            b.ipv6.push(a);
+          }
+        }
+      }
+    }
+    self.maybe_emit(inst_key);
+    if self.hosts_queried.insert(host_key.clone()) {
+      vec![
+        Start {
+          name: host.clone(),
+          step: Step::A(host_key.clone()),
+        },
+        Start {
+          name: host,
+          step: Step::Aaaa(host_key),
+        },
+      ]
+    } else {
+      Vec::new()
+    }
+  }
+
+  fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
+    if let Some(b) = self.builders.get_mut(inst_key) {
+      b.txt = Some(segs);
+    }
+    self.maybe_emit(inst_key);
+  }
+
+  /// An A/AAAA answer for a host: cache it and apply it to every instance whose
+  /// SRV already pointed at that host.
+  fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
+    let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
+    match addr {
+      IpAddr::V4(a) => {
+        if !cache.ipv4.contains(&a) {
+          cache.ipv4.push(a);
+        }
+      }
+      IpAddr::V6(a) => {
+        if !cache.ipv6.contains(&a) {
+          cache.ipv6.push(a);
+        }
+      }
+    }
+    let keys: Vec<String> = self
       .builders
       .iter()
       .filter(|(_, b)| b.host_key.as_deref() == Some(host_key))
       .map(|(k, _)| k.clone())
-      .collect()
+      .collect();
+    for k in keys {
+      if let Some(b) = self.builders.get_mut(&k) {
+        match addr {
+          IpAddr::V4(a) => {
+            if !b.ipv4.contains(&a) {
+              b.ipv4.push(a);
+            }
+          }
+          IpAddr::V6(a) => {
+            if !b.ipv6.contains(&a) {
+              b.ipv6.push(a);
+            }
+          }
+        }
+      }
+      self.maybe_emit(&k);
+    }
   }
 
-  /// Emit the instance as a [`ServiceEntry`] if it just became complete.
   fn maybe_emit(&mut self, inst_key: &str) {
     if let Some(b) = self.builders.get_mut(inst_key) {
       if !b.emitted && b.complete() {
@@ -353,13 +397,108 @@ impl Lookup {
     }
   }
 
+  fn take_ready(&mut self) -> Option<ServiceEntry> {
+    self.ready.pop_front()
+  }
+}
+
+/// A running DNS-SD lookup.
+///
+/// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
+/// complete; it returns `None` once every query (browse + resolves) has timed
+/// out. Dropping the `Lookup` cancels all of its in-flight queries.
+pub struct Lookup {
+  endpoint: Endpoint,
+  streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
+  resolver: Resolver,
+  resolve_timeout: Duration,
+  unicast: bool,
+}
+
+impl Lookup {
+  /// Wait for the next resolved service instance, or `None` when the lookup is
+  /// finished (all queries timed out).
+  pub async fn next(&mut self) -> Option<ServiceEntry> {
+    loop {
+      if let Some(entry) = self.resolver.take_ready() {
+        return Some(entry);
+      }
+      let tagged = self.streams.next().await?;
+      self.process(tagged).await;
+    }
+  }
+
+  /// Number of distinct instances dropped because the [`QueryParam`] cap was
+  /// reached. A non-zero value means the result set is a partial view.
+  pub fn dropped(&self) -> u64 {
+    self.resolver.dropped
+  }
+
+  async fn process(&mut self, tagged: Tagged) {
+    let answer = match tagged.event {
+      QueryEvent::Answer(a) => a,
+      QueryEvent::Terminal(_) => return,
+    };
+    let starts = match tagged.step {
+      Step::Ptr => {
+        if answer.rtype() != ResourceType::Ptr {
+          return;
+        }
+        match parse_name(answer.rdata_slice()) {
+          Some(instance) => self.resolver.on_ptr(instance),
+          None => return,
+        }
+      }
+      Step::Srv(inst_key) => {
+        if answer.rtype() != ResourceType::Srv {
+          return;
+        }
+        match parse_srv(answer.rdata_slice()) {
+          Some((host, port)) => self.resolver.on_srv(&inst_key, host, port),
+          None => return,
+        }
+      }
+      Step::Txt(inst_key) => {
+        if answer.rtype() != ResourceType::Txt {
+          return;
+        }
+        self
+          .resolver
+          .on_txt(&inst_key, parse_txt(answer.rdata_slice()));
+        Vec::new()
+      }
+      Step::A(host_key) => {
+        match ARecord::try_from_rdata(answer.rdata_slice()) {
+          Ok(r) if answer.rtype() == ResourceType::A => {
+            self.resolver.on_addr(&host_key, IpAddr::V4(r.addr()));
+          }
+          _ => return,
+        }
+        Vec::new()
+      }
+      Step::Aaaa(host_key) => {
+        match AaaaRecord::try_from_rdata(answer.rdata_slice()) {
+          Ok(r) if answer.rtype() == ResourceType::Aaaa => {
+            self.resolver.on_addr(&host_key, IpAddr::V6(r.addr()));
+          }
+          _ => return,
+        }
+        Vec::new()
+      }
+    };
+    for start in starts {
+      self.launch(start).await;
+    }
+  }
+
   /// Start a resolve sub-query and fold its answers into the merged stream.
-  async fn start(&mut self, name: Name, qtype: ResourceType, step: Step) {
-    let spec = QuerySpec::new(name, qtype)
+  async fn launch(&mut self, start: Start) {
+    let qtype = start.qtype();
+    let spec = QuerySpec::new(start.name, qtype)
       .with_timeout(self.resolve_timeout)
       .with_unicast_response(self.unicast);
     if let Ok(query) = self.endpoint.start_query(spec).await {
-      self.streams.push(tagged_stream(query, step));
+      self.streams.push(tagged_stream(query, start.step));
     }
   }
 }
@@ -378,9 +517,7 @@ impl Endpoint {
     Ok(Lookup {
       endpoint: self.clone(),
       streams,
-      builders: HashMap::new(),
-      hosts_queried: HashSet::new(),
-      ready: VecDeque::new(),
+      resolver: Resolver::new(param.max_entries),
       resolve_timeout,
       unicast: param.unicast_response,
     })
@@ -417,6 +554,10 @@ fn fold(name: &Name) -> String {
 
 /// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
 /// stored in a [`mdns_proto::CollectedAnswer`]) into an owned [`Name`].
+///
+/// Returns `None` for any name the [`Name`] type cannot represent faithfully:
+/// a label containing a `.` (always a separator) or a non-ASCII byte (mangled
+/// by `Name`). Such instances are skipped rather than silently corrupted.
 fn name_from_ref(nr: &NameRef<'_>) -> Option<Name> {
   let mut s = String::new();
   for label in nr.labels() {
@@ -424,7 +565,11 @@ fn name_from_ref(nr: &NameRef<'_>) -> Option<Name> {
     if label.is_empty() {
       break; // root terminator
     }
-    s.push_str(&String::from_utf8_lossy(label));
+    if label.iter().any(|&b| b >= 0x80 || b == b'.') {
+      return None; // not representable by `Name` without corruption
+    }
+    // Verified ASCII above, so this is always valid UTF-8.
+    s.push_str(core::str::from_utf8(label).ok()?);
     s.push('.');
   }
   if s.is_empty() {
@@ -453,4 +598,123 @@ fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
     .map_while(Result::ok)
     .map(<[u8]>::to_vec)
     .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+  use super::*;
+
+  /// Encode a single label sequence as a decompressed wire-form name.
+  fn wire_name(labels: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for l in labels {
+      out.push(u8::try_from(l.len()).unwrap());
+      out.extend_from_slice(l);
+    }
+    out.push(0);
+    out
+  }
+
+  fn ptr_rdata(labels: &[&[u8]]) -> Vec<u8> {
+    wire_name(labels)
+  }
+
+  fn srv_rdata(port: u16, host: &[&[u8]]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&0u16.to_be_bytes()); // priority
+    out.extend_from_slice(&0u16.to_be_bytes()); // weight
+    out.extend_from_slice(&port.to_be_bytes());
+    out.extend_from_slice(&wire_name(host));
+    out
+  }
+
+  #[test]
+  fn name_reconstruction_rejects_unrepresentable_labels() {
+    // Plain ASCII labels round-trip (case-folded).
+    assert_eq!(
+      parse_name(&ptr_rdata(&[b"MyPrinter", b"_ipp", b"_tcp", b"local"]))
+        .unwrap()
+        .as_str(),
+      "myprinter._ipp._tcp.local."
+    );
+    // A label containing a literal '.' cannot be represented — skip it.
+    assert!(parse_name(&ptr_rdata(&[b"weird.name", b"_tcp", b"local"])).is_none());
+    // A non-ASCII (UTF-8) label cannot round-trip through `Name` — skip it.
+    assert!(parse_name(&ptr_rdata(&[b"caf\xc3\xa9", b"local"])).is_none());
+  }
+
+  #[test]
+  fn flood_is_capped_and_observable() {
+    let mut r = Resolver::new(2);
+    let mk = |n: &str| Name::try_from_str(n).unwrap();
+    assert_eq!(r.on_ptr(mk("a._x._tcp.local.")).len(), 2); // SRV + TXT
+    assert_eq!(r.on_ptr(mk("b._x._tcp.local.")).len(), 2);
+    // Third instance is over the cap: no follow-ups, counted as dropped.
+    assert!(r.on_ptr(mk("c._x._tcp.local.")).is_empty());
+    assert_eq!(r.builders.len(), 2);
+    assert_eq!(r.dropped, 1);
+    // A duplicate of an existing instance is ignored without counting a drop.
+    assert!(r.on_ptr(mk("a._x._tcp.local.")).is_empty());
+    assert_eq!(r.dropped, 1);
+  }
+
+  #[test]
+  fn shared_host_srv_after_a_still_resolves() {
+    // Two instances share one host. The host's A answer arrives BEFORE the
+    // second instance's SRV — the second instance must still pick up the
+    // address from the host cache and complete.
+    let mut r = Resolver::new(16);
+    let i1 = Name::try_from_str("i1._x._tcp.local.").unwrap();
+    let i2 = Name::try_from_str("i2._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k1 = fold(&i1);
+    let k2 = fold(&i2);
+    let hk = fold(&host);
+
+    r.on_ptr(i1);
+    r.on_ptr(i2);
+    // i1 resolves: host + port, then its host gets an address.
+    r.on_srv(&k1, host.clone(), 8080);
+    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+    // i1 is now complete.
+    let first = r.take_ready().expect("i1 should complete");
+    assert_eq!(first.instance_name().as_str(), "i1._x._tcp.local.");
+    assert_eq!(first.ipv4_addresses(), [Ipv4Addr::new(10, 0, 0, 1)]);
+
+    // i2's SRV arrives AFTER the A answer. It must adopt the cached address.
+    r.on_srv(&k2, host, 8081);
+    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    let second = r
+      .take_ready()
+      .expect("i2 should complete from the host cache");
+    assert_eq!(second.instance_name().as_str(), "i2._x._tcp.local.");
+    assert_eq!(second.port(), 8081);
+    assert_eq!(second.ipv4_addresses(), [Ipv4Addr::new(10, 0, 0, 1)]);
+  }
+
+  #[test]
+  fn srv_parse_extracts_host_and_port() {
+    let (host, port) = parse_srv(&srv_rdata(631, &[b"printer", b"local"])).unwrap();
+    assert_eq!(host.as_str(), "printer.local.");
+    assert_eq!(port, 631);
+  }
+
+  #[test]
+  fn entry_incomplete_without_address_or_port_or_txt() {
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k = fold(&inst);
+    let hk = fold(&host);
+    r.on_ptr(inst);
+    // Only an address + port, no TXT yet → not complete.
+    r.on_srv(&k, host, 9000);
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+    assert!(r.take_ready().is_none(), "must not emit without TXT");
+    // TXT arrives → now complete.
+    r.on_txt(&k, vec![Vec::new()]); // empty TXT (single empty segment) counts
+    assert!(r.take_ready().is_some(), "complete once TXT present");
+  }
 }

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -1,0 +1,456 @@
+//! DNS-SD service discovery — browse a service type and resolve each instance
+//! into a fully-populated [`ServiceEntry`].
+//!
+//! This is the high-level client layer over [`Endpoint::start_query`]. A
+//! [`Lookup`] performs the RFC 6763 browse → resolve chain:
+//!
+//! 1. **Browse** (§4.1): a PTR query for the service type
+//!    (`_service._proto.local.`) yields the names of the published instances.
+//! 2. **Resolve** (§5): for each instance, an SRV query gives the target host
+//!    and port and a TXT query gives the metadata.
+//! 3. **Address** (§5): A / AAAA queries against the SRV target host give the
+//!    reachable addresses.
+//!
+//! An instance is surfaced as a [`ServiceEntry`] once it has a port (SRV), TXT
+//! data, and at least one address — matching the completeness rule of the
+//! original client. Each step is a real [`crate::Query`], so retransmission,
+//! caching, and TTL handling are inherited from the proto/driver layers; the
+//! whole lookup is bounded by the per-query timeouts and is cancelled by
+//! dropping the [`Lookup`].
+
+use std::{
+  collections::{HashMap, HashSet, VecDeque},
+  net::{IpAddr, Ipv4Addr, Ipv6Addr},
+  time::Duration,
+};
+
+use futures::{StreamExt, stream::SelectAll};
+use mdns_proto::{
+  Name, QuerySpec,
+  wire::{ARecord, AaaaRecord, NameRef, PtrRecord, ResourceType, SrvRecord, TxtRecord},
+};
+
+use crate::{Endpoint, QueryEvent, error::StartQueryError, query::Query};
+
+/// A resolved DNS-SD service instance.
+///
+/// Produced by [`Lookup::next`] once the instance's SRV (host + port), TXT, and
+/// at least one address have been collected.
+#[derive(Debug, Clone)]
+pub struct ServiceEntry {
+  instance: Name,
+  host: Name,
+  port: u16,
+  ipv4: Vec<Ipv4Addr>,
+  ipv6: Vec<Ipv6Addr>,
+  txt: Vec<Vec<u8>>,
+}
+
+impl ServiceEntry {
+  /// The fully-qualified service instance name (the PTR target), e.g.
+  /// `My Printer._ipp._tcp.local.`.
+  #[inline]
+  pub fn instance_name(&self) -> &Name {
+    &self.instance
+  }
+
+  /// The target host the SRV record points at, e.g. `printer.local.`.
+  #[inline]
+  pub fn host(&self) -> &Name {
+    &self.host
+  }
+
+  /// The service port from the SRV record.
+  #[inline]
+  pub const fn port(&self) -> u16 {
+    self.port
+  }
+
+  /// The host's IPv4 addresses (may be empty if only IPv6 resolved).
+  #[inline]
+  pub fn ipv4_addresses(&self) -> &[Ipv4Addr] {
+    &self.ipv4
+  }
+
+  /// The host's IPv6 addresses (may be empty if only IPv4 resolved).
+  #[inline]
+  pub fn ipv6_addresses(&self) -> &[Ipv6Addr] {
+    &self.ipv6
+  }
+
+  /// All resolved addresses (IPv4 first, then IPv6).
+  pub fn addresses(&self) -> impl Iterator<Item = IpAddr> + '_ {
+    self
+      .ipv4
+      .iter()
+      .copied()
+      .map(IpAddr::V4)
+      .chain(self.ipv6.iter().copied().map(IpAddr::V6))
+  }
+
+  /// The raw TXT record segments (each a length-prefixed `key=value` string in
+  /// DNS-SD usage, but treated as opaque bytes since TXT data may be binary). A
+  /// service with no metadata has a single empty segment (RFC 6763 §6.1).
+  #[inline]
+  pub fn txt(&self) -> &[Vec<u8>] {
+    &self.txt
+  }
+}
+
+/// Parameters for a [`Lookup`] / browse.
+#[derive(Debug, Clone)]
+pub struct QueryParam {
+  service: Name,
+  timeout: Duration,
+  resolve_timeout: Option<Duration>,
+  unicast_response: bool,
+}
+
+impl QueryParam {
+  /// Browse the given fully-qualified service type, e.g.
+  /// `Name::try_from_str("_ipp._tcp.local.")`.
+  pub fn new(service: Name) -> Self {
+    Self {
+      service,
+      timeout: Duration::from_secs(1),
+      resolve_timeout: None,
+      unicast_response: false,
+    }
+  }
+
+  /// How long the browse (the PTR query) runs before terminating.
+  #[must_use]
+  pub const fn with_timeout(mut self, timeout: Duration) -> Self {
+    self.timeout = timeout;
+    self
+  }
+
+  /// How long each per-instance resolve query (SRV / TXT / A / AAAA) runs.
+  /// Defaults to the browse timeout.
+  #[must_use]
+  pub const fn with_resolve_timeout(mut self, timeout: Duration) -> Self {
+    self.resolve_timeout = Some(timeout);
+    self
+  }
+
+  /// Request unicast responses on the issued queries (RFC 6762 §5.4). Defaults
+  /// to `false` (standard multicast browse).
+  #[must_use]
+  pub const fn with_unicast_response(mut self, unicast: bool) -> Self {
+    self.unicast_response = unicast;
+    self
+  }
+}
+
+/// Which resolve step an answer belongs to. The string is the case-folded key
+/// of the owning instance (SRV/TXT) or host (A/AAAA).
+#[derive(Clone)]
+enum Step {
+  Ptr,
+  Srv(String),
+  Txt(String),
+  A(String),
+  Aaaa(String),
+}
+
+/// One answer, tagged with the resolve step that produced it.
+struct Tagged {
+  step: Step,
+  event: QueryEvent,
+}
+
+/// In-progress aggregation of one service instance.
+struct Builder {
+  instance: Name,
+  host: Option<Name>,
+  host_key: Option<String>,
+  port: u16,
+  ipv4: Vec<Ipv4Addr>,
+  ipv6: Vec<Ipv6Addr>,
+  txt: Option<Vec<Vec<u8>>>,
+  emitted: bool,
+}
+
+impl Builder {
+  fn new(instance: Name) -> Self {
+    Self {
+      instance,
+      host: None,
+      host_key: None,
+      port: 0,
+      ipv4: Vec::new(),
+      ipv6: Vec::new(),
+      txt: None,
+      emitted: false,
+    }
+  }
+
+  /// Complete once it has a port (SRV), TXT, and at least one address.
+  fn complete(&self) -> bool {
+    self.port != 0 && self.txt.is_some() && !(self.ipv4.is_empty() && self.ipv6.is_empty())
+  }
+
+  fn finalize(&self) -> Option<ServiceEntry> {
+    Some(ServiceEntry {
+      instance: self.instance.clone(),
+      host: self.host.clone()?,
+      port: self.port,
+      ipv4: self.ipv4.clone(),
+      ipv6: self.ipv6.clone(),
+      txt: self.txt.clone()?,
+    })
+  }
+}
+
+/// A running DNS-SD lookup.
+///
+/// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
+/// complete; it returns `None` once every query (browse + resolves) has timed
+/// out. Dropping the `Lookup` cancels all of its in-flight queries.
+pub struct Lookup {
+  endpoint: Endpoint,
+  streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
+  builders: HashMap<String, Builder>,
+  hosts_queried: HashSet<String>,
+  ready: VecDeque<ServiceEntry>,
+  resolve_timeout: Duration,
+  unicast: bool,
+}
+
+impl Lookup {
+  /// Wait for the next resolved service instance, or `None` when the lookup is
+  /// finished (all queries timed out).
+  pub async fn next(&mut self) -> Option<ServiceEntry> {
+    loop {
+      if let Some(entry) = self.ready.pop_front() {
+        return Some(entry);
+      }
+      let tagged = self.streams.next().await?;
+      self.process(tagged).await;
+    }
+  }
+
+  async fn process(&mut self, tagged: Tagged) {
+    let answer = match tagged.event {
+      QueryEvent::Answer(a) => a,
+      QueryEvent::Terminal(_) => return,
+    };
+    match tagged.step {
+      Step::Ptr => {
+        if answer.rtype() != ResourceType::Ptr {
+          return;
+        }
+        let Some(instance) = parse_name(answer.rdata_slice()) else {
+          return;
+        };
+        let key = fold(&instance);
+        if self.builders.contains_key(&key) {
+          return; // already discovered this instance
+        }
+        self
+          .builders
+          .insert(key.clone(), Builder::new(instance.clone()));
+        self
+          .start(instance.clone(), ResourceType::Srv, Step::Srv(key.clone()))
+          .await;
+        self
+          .start(instance, ResourceType::Txt, Step::Txt(key))
+          .await;
+      }
+      Step::Srv(inst_key) => {
+        if answer.rtype() != ResourceType::Srv {
+          return;
+        }
+        let Some((host, port)) = parse_srv(answer.rdata_slice()) else {
+          return;
+        };
+        let host_key = fold(&host);
+        if let Some(b) = self.builders.get_mut(&inst_key) {
+          b.host = Some(host.clone());
+          b.host_key = Some(host_key.clone());
+          b.port = port;
+        }
+        if self.hosts_queried.insert(host_key.clone()) {
+          self
+            .start(host.clone(), ResourceType::A, Step::A(host_key.clone()))
+            .await;
+          self
+            .start(host, ResourceType::Aaaa, Step::Aaaa(host_key))
+            .await;
+        }
+        self.maybe_emit(&inst_key);
+      }
+      Step::Txt(inst_key) => {
+        if answer.rtype() != ResourceType::Txt {
+          return;
+        }
+        let segs = parse_txt(answer.rdata_slice());
+        if let Some(b) = self.builders.get_mut(&inst_key) {
+          b.txt = Some(segs);
+        }
+        self.maybe_emit(&inst_key);
+      }
+      Step::A(host_key) => {
+        if answer.rtype() != ResourceType::A {
+          return;
+        }
+        let Some(addr) = ARecord::try_from_rdata(answer.rdata_slice())
+          .ok()
+          .map(|r| r.addr())
+        else {
+          return;
+        };
+        for inst_key in self.builders_for_host(&host_key) {
+          if let Some(b) = self.builders.get_mut(&inst_key) {
+            if !b.ipv4.contains(&addr) {
+              b.ipv4.push(addr);
+            }
+          }
+          self.maybe_emit(&inst_key);
+        }
+      }
+      Step::Aaaa(host_key) => {
+        if answer.rtype() != ResourceType::Aaaa {
+          return;
+        }
+        let Some(addr) = AaaaRecord::try_from_rdata(answer.rdata_slice())
+          .ok()
+          .map(|r| r.addr())
+        else {
+          return;
+        };
+        for inst_key in self.builders_for_host(&host_key) {
+          if let Some(b) = self.builders.get_mut(&inst_key) {
+            if !b.ipv6.contains(&addr) {
+              b.ipv6.push(addr);
+            }
+          }
+          self.maybe_emit(&inst_key);
+        }
+      }
+    }
+  }
+
+  /// Instance keys whose SRV target host matches `host_key`.
+  fn builders_for_host(&self, host_key: &str) -> Vec<String> {
+    self
+      .builders
+      .iter()
+      .filter(|(_, b)| b.host_key.as_deref() == Some(host_key))
+      .map(|(k, _)| k.clone())
+      .collect()
+  }
+
+  /// Emit the instance as a [`ServiceEntry`] if it just became complete.
+  fn maybe_emit(&mut self, inst_key: &str) {
+    if let Some(b) = self.builders.get_mut(inst_key) {
+      if !b.emitted && b.complete() {
+        if let Some(entry) = b.finalize() {
+          b.emitted = true;
+          self.ready.push_back(entry);
+        }
+      }
+    }
+  }
+
+  /// Start a resolve sub-query and fold its answers into the merged stream.
+  async fn start(&mut self, name: Name, qtype: ResourceType, step: Step) {
+    let spec = QuerySpec::new(name, qtype)
+      .with_timeout(self.resolve_timeout)
+      .with_unicast_response(self.unicast);
+    if let Ok(query) = self.endpoint.start_query(spec).await {
+      self.streams.push(tagged_stream(query, step));
+    }
+  }
+}
+
+impl Endpoint {
+  /// Browse for instances of a DNS-SD service type, resolving each into a
+  /// [`ServiceEntry`]. See [`Lookup`] and [`QueryParam`].
+  pub async fn browse(&self, param: QueryParam) -> Result<Lookup, StartQueryError> {
+    let resolve_timeout = param.resolve_timeout.unwrap_or(param.timeout);
+    let ptr_spec = QuerySpec::new(param.service, ResourceType::Ptr)
+      .with_timeout(param.timeout)
+      .with_unicast_response(param.unicast_response);
+    let ptr_query = self.start_query(ptr_spec).await?;
+    let mut streams = SelectAll::new();
+    streams.push(tagged_stream(ptr_query, Step::Ptr));
+    Ok(Lookup {
+      endpoint: self.clone(),
+      streams,
+      builders: HashMap::new(),
+      hosts_queried: HashSet::new(),
+      ready: VecDeque::new(),
+      resolve_timeout,
+      unicast: param.unicast_response,
+    })
+  }
+
+  /// Convenience for [`Self::browse`] with default parameters and the given
+  /// browse timeout.
+  pub async fn lookup(&self, service: Name, timeout: Duration) -> Result<Lookup, StartQueryError> {
+    self
+      .browse(QueryParam::new(service).with_timeout(timeout))
+      .await
+  }
+}
+
+/// Wrap a [`Query`] as a `'static` stream of [`Tagged`] answers for the given
+/// resolve step. The stream ends when the query reaches its terminal.
+fn tagged_stream(query: Query, step: Step) -> futures::stream::BoxStream<'static, Tagged> {
+  futures::stream::unfold((query, step), |(mut query, step)| async move {
+    let event = query.next().await?;
+    let tagged = Tagged {
+      step: step.clone(),
+      event,
+    };
+    Some((tagged, (query, step)))
+  })
+  .boxed()
+}
+
+/// Case-fold a name to its lookup key (DNS names are case-insensitive,
+/// RFC 6762 §16).
+fn fold(name: &Name) -> String {
+  name.as_str().to_ascii_lowercase()
+}
+
+/// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
+/// stored in a [`mdns_proto::CollectedAnswer`]) into an owned [`Name`].
+fn name_from_ref(nr: &NameRef<'_>) -> Option<Name> {
+  let mut s = String::new();
+  for label in nr.labels() {
+    let label = label.ok()?;
+    if label.is_empty() {
+      break; // root terminator
+    }
+    s.push_str(&String::from_utf8_lossy(label));
+    s.push('.');
+  }
+  if s.is_empty() {
+    return None;
+  }
+  Name::try_from_str(&s).ok()
+}
+
+/// Parse a PTR rdata slice (a decompressed wire-form name) into a [`Name`].
+fn parse_name(rdata: &[u8]) -> Option<Name> {
+  let ptr = PtrRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
+  name_from_ref(ptr.target())
+}
+
+/// Parse an SRV rdata slice into `(target host, port)`.
+fn parse_srv(rdata: &[u8]) -> Option<(Name, u16)> {
+  let srv = SrvRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
+  let host = name_from_ref(srv.target())?;
+  Some((host, srv.port()))
+}
+
+/// Parse a TXT rdata slice into its segments (dropping a malformed tail).
+fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
+  TxtRecord::from_rdata(rdata)
+    .segments()
+    .map_while(Result::ok)
+    .map(<[u8]>::to_vec)
+    .collect()
+}

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -331,15 +331,22 @@ impl Resolver {
   fn on_srv(&mut self, inst_key: &str, host: Name, port: u16) -> Vec<Start> {
     let host_key = fold(&host);
     let cached = self.host_addrs.get(&host_key);
+    let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
+      let host_changed = b.host_key.as_deref() != Some(host_key.as_str());
       // SRV retargeting the instance to a DIFFERENT host invalidates the old
       // host's addresses — drop them before adopting the new host's, so a
       // re-emit never yields an entry whose host is the new target but whose
       // addresses still belong to the old one.
-      if b.host_key.as_deref() != Some(host_key.as_str()) {
+      if host_changed {
         b.ipv4.clear();
         b.ipv6.clear();
       }
+      // A host or port change to an already-surfaced instance must re-emit even
+      // when the new host's addresses are already cached — no fresh A/AAAA event
+      // will arrive to trigger the re-emit, so without this the consumer keeps a
+      // stale host/port.
+      changed = host_changed || b.port != port;
       b.host = Some(host.clone());
       b.host_key = Some(host_key.clone());
       b.port = port;
@@ -352,7 +359,7 @@ impl Resolver {
         }
       }
     }
-    self.try_emit(inst_key, false);
+    self.try_emit(inst_key, changed);
     if self.hosts_queried.contains(&host_key) {
       return Vec::new(); // already querying this host
     }
@@ -682,7 +689,13 @@ impl Endpoint {
     let resolve_timeout = param.resolve_timeout.unwrap_or(param.timeout);
     let ptr_spec = QuerySpec::new(param.service, ResourceType::Ptr)
       .with_timeout(param.timeout)
-      .with_unicast_response(param.unicast_response);
+      .with_unicast_response(param.unicast_response)
+      // Size the PTR answer pool to the requested instance cap so a max_entries
+      // above the query's default answer cap is actually reachable, and the
+      // Resolver — not the query's answer pool — is what bounds and counts
+      // instances (`Lookup::dropped`). Without this, surplus PTR answers would be
+      // evicted before `on_ptr` could track or count them.
+      .with_max_answers(param.max_entries);
     // Start the browse query up front so a start failure surfaces synchronously
     // to the caller rather than vanishing inside the spawned task.
     let ptr_query = self.start_query(ptr_spec).await?;
@@ -1051,6 +1064,55 @@ mod tests {
       second.ipv4_addresses(),
       [Ipv4Addr::new(10, 0, 0, 2)],
       "stale h1 address must not survive the retarget"
+    );
+  }
+
+  #[test]
+  fn srv_retarget_to_cached_host_reemits() {
+    // An already-emitted instance retargets to a host whose addresses are
+    // ALREADY cached (shared with another instance). No fresh A/AAAA event will
+    // arrive, so the SRV change itself must re-emit the new host/port + adopted
+    // address rather than leaving the consumer with a stale entry.
+    let mut r = Resolver::new(16);
+    let i1 = Name::try_from_str("i1._x._tcp.local.").unwrap();
+    let i2 = Name::try_from_str("i2._x._tcp.local.").unwrap();
+    let shared = Name::try_from_str("shared.local.").unwrap();
+    let other = Name::try_from_str("other.local.").unwrap();
+    let k1 = fold(&i1);
+    let k2 = fold(&i2);
+    let shk = fold(&shared);
+    let ohk = fold(&other);
+
+    // i1 resolves on `shared`, populating the host-address cache.
+    r.on_ptr(i1);
+    r.on_srv(&k1, shared.clone(), 8000);
+    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_addr(&shk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)));
+    r.take_ready().expect("i1 resolves on shared");
+
+    // i2 first resolves on a DIFFERENT host.
+    r.on_ptr(i2);
+    r.on_srv(&k2, other, 9000);
+    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    r.on_addr(&ohk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)));
+    let i2_first = r.take_ready().expect("i2 resolves on other");
+    assert_eq!(i2_first.host().as_str(), "other.local.");
+
+    // i2's SRV now retargets to `shared` (already cached, already queried).
+    let starts = r.on_srv(&k2, shared, 9001);
+    assert!(
+      starts.is_empty(),
+      "shared host already queried — no new A/AAAA launched"
+    );
+    let i2_re = r
+      .take_ready()
+      .expect("i2 must re-emit on the cached host without a fresh address event");
+    assert_eq!(i2_re.host().as_str(), "shared.local.");
+    assert_eq!(i2_re.port(), 9001);
+    assert_eq!(
+      i2_re.ipv4_addresses(),
+      [Ipv4Addr::new(10, 0, 0, 9)],
+      "adopts the shared host's cached address, not the stale one"
     );
   }
 

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -41,6 +41,11 @@ use crate::{Endpoint, QueryEvent, error::StartQueryError, query::Query};
 /// or the in-flight sub-query set without bound.
 pub const DEFAULT_MAX_ENTRIES: usize = 64;
 
+/// Cap on the addresses kept per host per family (and per instance), so a
+/// responder flooding distinct A/AAAA records for one host cannot grow the
+/// address vectors (in the host cache or any builder) without bound.
+const MAX_ADDRS_PER_HOST: usize = 16;
+
 /// A resolved DNS-SD service instance.
 ///
 /// Produced by [`Lookup::next`] once the instance's SRV (host + port), TXT, and
@@ -181,6 +186,7 @@ struct Tagged {
 
 /// A follow-up query the driver should launch as a result of feeding the
 /// [`Resolver`] an answer.
+#[derive(Clone)]
 struct Start {
   name: Name,
   step: Step,
@@ -310,18 +316,14 @@ impl Resolver {
       b.port = port;
       if let Some(addrs) = cached {
         for &a in &addrs.ipv4 {
-          if !b.ipv4.contains(&a) {
-            b.ipv4.push(a);
-          }
+          push_capped(&mut b.ipv4, a);
         }
         for &a in &addrs.ipv6 {
-          if !b.ipv6.contains(&a) {
-            b.ipv6.push(a);
-          }
+          push_capped(&mut b.ipv6, a);
         }
       }
     }
-    self.maybe_emit(inst_key);
+    self.try_emit(inst_key, false);
     if self.hosts_queried.insert(host_key.clone()) {
       vec![
         Start {
@@ -342,25 +344,18 @@ impl Resolver {
     if let Some(b) = self.builders.get_mut(inst_key) {
       b.txt = Some(segs);
     }
-    self.maybe_emit(inst_key);
+    self.try_emit(inst_key, false);
   }
 
-  /// An A/AAAA answer for a host: cache it and apply it to every instance whose
-  /// SRV already pointed at that host.
+  /// An A/AAAA answer for a host: cache it (capped) and apply it to every
+  /// instance whose SRV already pointed at that host. A newly-added address may
+  /// re-emit an already-surfaced instance with the fuller address set.
   fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
     let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
     match addr {
-      IpAddr::V4(a) => {
-        if !cache.ipv4.contains(&a) {
-          cache.ipv4.push(a);
-        }
-      }
-      IpAddr::V6(a) => {
-        if !cache.ipv6.contains(&a) {
-          cache.ipv6.push(a);
-        }
-      }
-    }
+      IpAddr::V4(a) => push_capped(&mut cache.ipv4, a),
+      IpAddr::V6(a) => push_capped(&mut cache.ipv6, a),
+    };
     let keys: Vec<String> = self
       .builders
       .iter()
@@ -368,29 +363,34 @@ impl Resolver {
       .map(|(k, _)| k.clone())
       .collect();
     for k in keys {
-      if let Some(b) = self.builders.get_mut(&k) {
-        match addr {
-          IpAddr::V4(a) => {
-            if !b.ipv4.contains(&a) {
-              b.ipv4.push(a);
-            }
-          }
-          IpAddr::V6(a) => {
-            if !b.ipv6.contains(&a) {
-              b.ipv6.push(a);
-            }
-          }
-        }
+      let added = match self.builders.get_mut(&k) {
+        Some(b) => match addr {
+          IpAddr::V4(a) => push_capped(&mut b.ipv4, a),
+          IpAddr::V6(a) => push_capped(&mut b.ipv6, a),
+        },
+        None => false,
+      };
+      if added {
+        self.try_emit(&k, true);
       }
-      self.maybe_emit(&k);
     }
   }
 
-  fn maybe_emit(&mut self, inst_key: &str) {
+  /// Emit the instance if it is complete: the first time it completes, or — when
+  /// `allow_reemit` — again with an updated snapshot (e.g. a late AAAA after the
+  /// entry was first surfaced on its A address).
+  fn try_emit(&mut self, inst_key: &str, allow_reemit: bool) {
     if let Some(b) = self.builders.get_mut(inst_key) {
-      if !b.emitted && b.complete() {
+      if !b.complete() {
+        return;
+      }
+      if !b.emitted {
         if let Some(entry) = b.finalize() {
           b.emitted = true;
+          self.ready.push_back(entry);
+        }
+      } else if allow_reemit {
+        if let Some(entry) = b.finalize() {
           self.ready.push_back(entry);
         }
       }
@@ -411,6 +411,10 @@ pub struct Lookup {
   endpoint: Endpoint,
   streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
   resolver: Resolver,
+  /// Follow-up queries discovered but not yet launched. Queued (rather than
+  /// launched inline) so that dropping the `next()` future mid-launch does not
+  /// lose them — they are retried on the next call.
+  pending_starts: VecDeque<Start>,
   resolve_timeout: Duration,
   unicast: bool,
 }
@@ -418,13 +422,27 @@ pub struct Lookup {
 impl Lookup {
   /// Wait for the next resolved service instance, or `None` when the lookup is
   /// finished (all queries timed out).
+  ///
+  /// An instance may be yielded more than once as additional addresses resolve
+  /// (e.g. a late AAAA after the entry was first surfaced on its A address); a
+  /// later yield for the same [`ServiceEntry::instance_name`] supersedes the
+  /// earlier one. This method is cancellation-safe: dropping the future does
+  /// not lose queued follow-up queries.
   pub async fn next(&mut self) -> Option<ServiceEntry> {
     loop {
       if let Some(entry) = self.resolver.take_ready() {
         return Some(entry);
       }
+      // Launch queued follow-ups before polling for more answers. Peek-then-pop
+      // so a cancellation mid-launch leaves the start queued for a retry rather
+      // than dropping it (a benign double-start at worst).
+      if let Some(start) = self.pending_starts.front().cloned() {
+        self.launch(start).await;
+        self.pending_starts.pop_front();
+        continue;
+      }
       let tagged = self.streams.next().await?;
-      self.process(tagged).await;
+      self.process(tagged);
     }
   }
 
@@ -434,7 +452,7 @@ impl Lookup {
     self.resolver.dropped
   }
 
-  async fn process(&mut self, tagged: Tagged) {
+  fn process(&mut self, tagged: Tagged) {
     let answer = match tagged.event {
       QueryEvent::Answer(a) => a,
       QueryEvent::Terminal(_) => return,
@@ -486,9 +504,7 @@ impl Lookup {
         Vec::new()
       }
     };
-    for start in starts {
-      self.launch(start).await;
-    }
+    self.pending_starts.extend(starts);
   }
 
   /// Start a resolve sub-query and fold its answers into the merged stream.
@@ -518,6 +534,7 @@ impl Endpoint {
       endpoint: self.clone(),
       streams,
       resolver: Resolver::new(param.max_entries),
+      pending_starts: VecDeque::new(),
       resolve_timeout,
       unicast: param.unicast_response,
     })
@@ -544,6 +561,16 @@ fn tagged_stream(query: Query, step: Step) -> futures::stream::BoxStream<'static
     Some((tagged, (query, step)))
   })
   .boxed()
+}
+
+/// Push `item` into `v` if it is new and `v` is under [`MAX_ADDRS_PER_HOST`].
+/// Returns `true` if it was added (so the caller can decide to (re)emit).
+fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
+  if v.len() >= MAX_ADDRS_PER_HOST || v.contains(&item) {
+    return false;
+  }
+  v.push(item);
+  true
 }
 
 /// Case-fold a name to its lookup key (DNS names are case-insensitive,
@@ -716,5 +743,87 @@ mod tests {
     // TXT arrives → now complete.
     r.on_txt(&k, vec![Vec::new()]); // empty TXT (single empty segment) counts
     assert!(r.take_ready().is_some(), "complete once TXT present");
+  }
+
+  #[test]
+  fn address_fans_out_to_all_instances_on_shared_host() {
+    // Three instances share one host; the host's single A answer must complete
+    // all of them (each already had SRV + TXT).
+    let mut r = Resolver::new(16);
+    let host = Name::try_from_str("h.local.").unwrap();
+    let hk = fold(&host);
+    for label in ["i1", "i2", "i3"] {
+      let inst = Name::try_from_str(&format!("{label}._x._tcp.local.")).unwrap();
+      let k = fold(&inst);
+      r.on_ptr(inst);
+      r.on_srv(&k, host.clone(), 7000);
+      r.on_txt(&k, vec![b"k=v".to_vec()]);
+    }
+    assert!(
+      r.take_ready().is_none(),
+      "incomplete until an address arrives"
+    );
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    let mut emitted = HashSet::new();
+    while let Some(e) = r.take_ready() {
+      assert_eq!(e.ipv4_addresses(), [Ipv4Addr::new(192, 0, 2, 1)]);
+      emitted.insert(e.instance_name().as_str().to_owned());
+    }
+    assert_eq!(emitted.len(), 3, "all three shared-host instances resolve");
+  }
+
+  #[test]
+  fn late_address_reemits_updated_entry() {
+    // An entry first surfaces on its A address; a later AAAA re-emits it with
+    // the fuller address set rather than being dropped.
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k = fold(&inst);
+    let hk = fold(&host);
+    r.on_ptr(inst);
+    r.on_srv(&k, host, 7000);
+    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    let first = r.take_ready().expect("first emit on A");
+    assert_eq!(first.ipv4_addresses().len(), 1);
+    assert!(first.ipv6_addresses().is_empty());
+    // Late AAAA → re-emit with both families.
+    r.on_addr(&hk, IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)));
+    let second = r.take_ready().expect("re-emit on late AAAA");
+    assert_eq!(second.ipv4_addresses().len(), 1);
+    assert_eq!(second.ipv6_addresses().len(), 1);
+    // A duplicate address must NOT re-emit again.
+    r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
+    assert!(
+      r.take_ready().is_none(),
+      "duplicate address must not re-emit"
+    );
+  }
+
+  #[test]
+  fn addresses_capped_per_host() {
+    // A responder flooding distinct A records for one host cannot grow the
+    // address vector past MAX_ADDRS_PER_HOST.
+    let mut r = Resolver::new(16);
+    let inst = Name::try_from_str("i._x._tcp.local.").unwrap();
+    let host = Name::try_from_str("h.local.").unwrap();
+    let k = fold(&inst);
+    let hk = fold(&host);
+    r.on_ptr(inst);
+    r.on_srv(&k, host, 7000);
+    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    for i in 0..(MAX_ADDRS_PER_HOST as u32 + 8) {
+      let o = i.to_be_bytes();
+      r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, o[1], o[2], o[3])));
+    }
+    let mut last = None;
+    while let Some(e) = r.take_ready() {
+      last = Some(e);
+    }
+    assert_eq!(
+      last.expect("at least one emit").ipv4_addresses().len(),
+      MAX_ADDRS_PER_HOST
+    );
   }
 }

--- a/agnostic-mdns/src/driver.rs
+++ b/agnostic-mdns/src/driver.rs
@@ -282,6 +282,13 @@ impl<N: Net> DriverState<N> {
         let _ = self.endpoint.cancel_query(handle);
         self.queries.remove(&handle);
       }
+      Command::SpawnLookup { task } => {
+        // spawn from WITHIN the driver task so the child inherits this task's
+        // runtime context — the endpoint may have been created on a different
+        // executor/thread than the caller of `browse()`, where a direct
+        // ambient `spawn` would panic (no entered runtime).
+        <N::Runtime as RuntimeLite>::spawn_detach(task);
+      }
     }
   }
 

--- a/agnostic-mdns/src/endpoint.rs
+++ b/agnostic-mdns/src/endpoint.rs
@@ -1,8 +1,7 @@
 //! Caller-side handle for an mDNS endpoint.
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::future::Future;
 
-use agnostic_lite::RuntimeLite;
 use agnostic_net::Net;
 use mdns_proto::{QuerySpec, ServiceSpec};
 use mdns_udp::{
@@ -18,13 +17,6 @@ use crate::{
   service::Service,
 };
 
-/// Type-erased detached-task spawner captured at [`Endpoint::server`] time. It
-/// lets the runtime-agnostic `Endpoint` spawn background tasks (e.g. a discovery
-/// [`Lookup`](crate::Lookup) driver) without itself being generic over the
-/// runtime — the concrete `N::Runtime` is closed over here, exactly as quinn's
-/// `Arc<dyn Runtime>` erases its spawner.
-type SpawnFn = Arc<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync>;
-
 /// Handle to a running mDNS endpoint.
 ///
 /// Cloneable; every clone shares the same underlying driver task. The driver
@@ -33,7 +25,6 @@ type SpawnFn = Arc<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Syn
 #[derive(Clone)]
 pub struct Endpoint {
   cmd: async_channel::Sender<Command>,
-  spawn: SpawnFn,
 }
 
 impl Endpoint {
@@ -112,21 +103,27 @@ impl Endpoint {
     };
     driver::spawn::<N>(opts, sockets, cmd_rx);
 
-    // close over the concrete runtime so type-erased clones of this endpoint
-    // can spawn background tasks (e.g. discovery lookups).
-    let spawn: SpawnFn = Arc::new(|fut: Pin<Box<dyn Future<Output = ()> + Send>>| {
-      <N::Runtime as RuntimeLite>::spawn_detach(fut);
-    });
-
-    Ok(Self { cmd: cmd_tx, spawn })
+    Ok(Self { cmd: cmd_tx })
   }
 
-  /// Spawn a detached background task on this endpoint's runtime.
-  pub(crate) fn spawn_task<F>(&self, fut: F)
+  /// Hand a detached discovery-lookup driver task to the driver to spawn (via
+  /// [`Command::SpawnLookup`]).
+  ///
+  /// Spawning happens inside the driver task, which always runs in the runtime
+  /// context the endpoint was created on. Routing it this way — rather than
+  /// spawning from the caller — means `browse()` works from any executor or
+  /// thread, even one with no entered runtime of its own, matching the
+  /// runtime-agnostic, channel-only nature of the rest of the endpoint API.
+  pub(crate) fn spawn_lookup<F>(&self, fut: F) -> Result<(), StartQueryError>
   where
     F: Future<Output = ()> + Send + 'static,
   {
-    (self.spawn)(Box::pin(fut));
+    self
+      .cmd
+      .try_send(Command::SpawnLookup {
+        task: Box::pin(fut),
+      })
+      .map_err(|_| StartQueryError::DriverGone)
   }
 
   /// Register a new service with the responder. The returned [`Service`]

--- a/agnostic-mdns/src/endpoint.rs
+++ b/agnostic-mdns/src/endpoint.rs
@@ -1,5 +1,8 @@
 //! Caller-side handle for an mDNS endpoint.
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use agnostic_lite::RuntimeLite;
 use agnostic_net::Net;
 use mdns_proto::{QuerySpec, ServiceSpec};
 use mdns_udp::{
@@ -15,6 +18,13 @@ use crate::{
   service::Service,
 };
 
+/// Type-erased detached-task spawner captured at [`Endpoint::server`] time. It
+/// lets the runtime-agnostic `Endpoint` spawn background tasks (e.g. a discovery
+/// [`Lookup`](crate::Lookup) driver) without itself being generic over the
+/// runtime — the concrete `N::Runtime` is closed over here, exactly as quinn's
+/// `Arc<dyn Runtime>` erases its spawner.
+type SpawnFn = Arc<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync>;
+
 /// Handle to a running mDNS endpoint.
 ///
 /// Cloneable; every clone shares the same underlying driver task. The driver
@@ -23,6 +33,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Endpoint {
   cmd: async_channel::Sender<Command>,
+  spawn: SpawnFn,
 }
 
 impl Endpoint {
@@ -101,7 +112,21 @@ impl Endpoint {
     };
     driver::spawn::<N>(opts, sockets, cmd_rx);
 
-    Ok(Self { cmd: cmd_tx })
+    // close over the concrete runtime so type-erased clones of this endpoint
+    // can spawn background tasks (e.g. discovery lookups).
+    let spawn: SpawnFn = Arc::new(|fut: Pin<Box<dyn Future<Output = ()> + Send>>| {
+      <N::Runtime as RuntimeLite>::spawn_detach(fut);
+    });
+
+    Ok(Self { cmd: cmd_tx, spawn })
+  }
+
+  /// Spawn a detached background task on this endpoint's runtime.
+  pub(crate) fn spawn_task<F>(&self, fut: F)
+  where
+    F: Future<Output = ()> + Send + 'static,
+  {
+    (self.spawn)(Box::pin(fut));
   }
 
   /// Register a new service with the responder. The returned [`Service`]

--- a/agnostic-mdns/src/lib.rs
+++ b/agnostic-mdns/src/lib.rs
@@ -31,6 +31,7 @@
 #![cfg_attr(docsrs, allow(unused_attributes))]
 
 mod command;
+mod discovery;
 mod driver;
 mod endpoint;
 mod error;
@@ -39,6 +40,7 @@ mod proto;
 mod query;
 mod service;
 
+pub use discovery::{Lookup, QueryParam, ServiceEntry};
 pub use endpoint::Endpoint;
 pub use error::{CancelError, RegisterError, ServerError, StartQueryError};
 pub use options::ServerOptions;

--- a/agnostic-mdns/src/query.rs
+++ b/agnostic-mdns/src/query.rs
@@ -183,6 +183,17 @@ impl Query {
     lock(&self.mailbox).dropped
   }
 
+  /// A cheap, cloneable view of this query's dropped-answer counter that stays
+  /// valid after the `Query` is moved (e.g. into a stream adapter). Shares the
+  /// mailbox, so it reports the same count as [`Self::dropped_answers`]. Used by
+  /// the discovery layer to fold the browse query's drops into
+  /// [`crate::Lookup::dropped`].
+  pub(crate) fn dropped_handle(&self) -> DroppedHandle {
+    DroppedHandle {
+      mailbox: Arc::clone(&self.mailbox),
+    }
+  }
+
   /// Wait for the next answer or terminal. Returns `None` once the query has
   /// ended (terminal delivered) or the driver task has exited.
   ///
@@ -233,6 +244,19 @@ impl Drop for Query {
     let _ = self.cmd.try_send(Command::CancelQuery {
       handle: self.handle,
     });
+  }
+}
+
+/// A cloneable view of a query's dropped-answer counter, decoupled from the
+/// [`Query`] handle's lifetime (see [`Query::dropped_handle`]).
+pub(crate) struct DroppedHandle {
+  mailbox: Arc<Mutex<QueryMailbox>>,
+}
+
+impl DroppedHandle {
+  /// The query's current dropped-answer count.
+  pub(crate) fn get(&self) -> u64 {
+    lock(&self.mailbox).dropped
   }
 }
 
@@ -398,5 +422,24 @@ mod tests {
     let (answers, got_terminal) = consumer.await.expect("consumer task panicked");
     assert_eq!(answers, 5);
     assert!(got_terminal);
+  }
+
+  #[test]
+  fn dropped_handle_tracks_mailbox_drops() {
+    // The handle shares the mailbox, so it keeps reflecting drops after the
+    // `Query` it came from has been moved away (e.g. into a stream adapter).
+    let (mailbox, _tx, _rx) = new_mailbox();
+    let handle = DroppedHandle {
+      mailbox: Arc::clone(&mailbox),
+    };
+    assert_eq!(handle.get(), 0);
+    // Upstream (proto-cap) evictions.
+    lock(&mailbox).record_dropped(4);
+    assert_eq!(handle.get(), 4);
+    // Mailbox drop-oldest under a flood folds into the same counter.
+    for i in 0..(MAX_QUERY_EVENT_BACKLOG as u16 + 3) {
+      lock(&mailbox).push_answer(answer(i));
+    }
+    assert_eq!(handle.get(), 4 + 3);
   }
 }

--- a/agnostic-mdns/tests/loopback_lookup.rs
+++ b/agnostic-mdns/tests/loopback_lookup.rs
@@ -305,11 +305,16 @@ async fn loopback_browse_resolves_service_entry() {
         e.port(),
         e.ipv4_addresses()
       );
+      // Wait for an instance of our type whose A address has resolved. On
+      // loopback the responder emits both A (127.0.0.1) and AAAA (::1) over
+      // IPv4, so the first emission for an instance may be AAAA-only; a later
+      // re-emission carries the A address.
       if e
         .instance_name()
         .as_str()
         .to_ascii_lowercase()
         .ends_with(&suffix)
+        && e.ipv4_addresses().contains(&ADVERTISED_V4.into())
       {
         return Some(e);
       }

--- a/agnostic-mdns/tests/loopback_lookup.rs
+++ b/agnostic-mdns/tests/loopback_lookup.rs
@@ -21,7 +21,7 @@
 use std::{net::Ipv6Addr, time::Duration};
 
 use agnostic_mdns::{
-  CollectedAnswer, Name, QueryEvent, QuerySpec, ServerOptions, Service, ServiceRecords,
+  CollectedAnswer, Name, QueryEvent, QueryParam, QuerySpec, ServerOptions, Service, ServiceRecords,
   ServiceSpec, tokio as tokio_drv, wire::ResourceType,
 };
 
@@ -267,4 +267,80 @@ async fn loopback_any_query_returns_full_record_set() {
   let saw_srv = answers.iter().any(|a| a.rtype() == ResourceType::Srv);
   let saw_txt = answers.iter().any(|a| a.rtype() == ResourceType::Txt);
   assert!(saw_srv && saw_txt, "expected SRV+TXT; got {answers:?}");
+}
+
+/// End-to-end DNS-SD discovery: browse the service type and resolve the
+/// published instance into a fully-populated `ServiceEntry` (PTR → SRV/TXT →
+/// A/AAAA chained by the `Lookup`).
+#[tokio::test]
+async fn loopback_browse_resolves_service_entry() {
+  let pair = match build_pair(Duration::from_millis(1300)).await {
+    Some(p) => p,
+    None => return,
+  };
+  let param = QueryParam::new(Name::try_from_str(UNIQUE_SERVICE).unwrap())
+    .with_timeout(Duration::from_secs(2));
+  let mut lookup = match pair.querier.browse(param).await {
+    Ok(l) => l,
+    Err(e) => {
+      eprintln!("skipping: browse failed: {e:?}");
+      return;
+    }
+  };
+
+  // Resolve until an instance of our service type appears (or a hard cap).
+  // Breaking on the first match keeps the test fast — the entry resolves long
+  // before the per-query timeouts elapse. We match on the service-type suffix,
+  // not the exact instance label: parallel tests publish the same instance name
+  // on loopback, so §9 conflict resolution renames clones (`Test` → `test-2`),
+  // and responders lowercase names on the wire. The host/port/addr/TXT are
+  // identical across the renamed clones, so any resolved entry validates them.
+  let suffix = UNIQUE_SERVICE.to_ascii_lowercase();
+  let entry = tokio::time::timeout(Duration::from_secs(5), async {
+    while let Some(e) = lookup.next().await {
+      eprintln!(
+        "browse entry: {} host={} port={} v4={:?}",
+        e.instance_name(),
+        e.host(),
+        e.port(),
+        e.ipv4_addresses()
+      );
+      if e
+        .instance_name()
+        .as_str()
+        .to_ascii_lowercase()
+        .ends_with(&suffix)
+      {
+        return Some(e);
+      }
+    }
+    None
+  })
+  .await
+  .ok()
+  .flatten();
+
+  let entry = match entry {
+    Some(e) => e,
+    None => panic!("browse did not resolve any instance of {UNIQUE_SERVICE}"),
+  };
+  assert_eq!(entry.port(), SERVICE_PORT, "wrong port");
+  assert!(
+    entry.host().as_str().eq_ignore_ascii_case(UNIQUE_HOST),
+    "wrong host: {}",
+    entry.host()
+  );
+  assert!(
+    entry.ipv4_addresses().contains(&ADVERTISED_V4.into()),
+    "expected {ADVERTISED_V4:?} in {:?}",
+    entry.ipv4_addresses()
+  );
+  assert!(
+    entry
+      .txt()
+      .iter()
+      .any(|t| t.as_slice() == b"Local web server"),
+    "expected TXT 'Local web server' in {:?}",
+    entry.txt()
+  );
 }


### PR DESCRIPTION
## Summary

- Adds a high-level DNS-SD discovery client (`Lookup` / `QueryParam` / `ServiceEntry`) layered over `Endpoint::start_query`, performing the RFC 6763 browse → resolve chain (PTR → SRV/TXT → A/AAAA) and surfacing each instance once it has an SRV (host + port), TXT, and at least one address.
- Modeled on quinn's `ConnectionDriver`: a spawned per-`Lookup` driver task owns the sub-queries plus a pure aggregation `Resolver`, and pushes resolved entries into shared state (`Arc<Mutex<LookupQueue>>` + a capacity-1 doorbell) that the `Lookup` handle drains — mirroring the existing `Query` mailbox/doorbell split. Resolution advances in its own task, so a slow consumer can't stall the sub-query mailboxes. Spawning is routed through the driver (`Command::SpawnLookup`) so `browse()` works from any executor/thread, with no entered runtime of its own required.
- Bounded and observable under hostile or chatty responders: caps on distinct instances (`QueryParam::with_max_entries`, sized into the PTR query's answer pool), distinct hosts (SRV-target flood guard), and addresses per host. Every drop path — instance cap, host cap, and browse-query answer-pool eviction — is counted in `Lookup::dropped()`. The lookup is cancelled by dropping the `Lookup` (which stops the task and cancels its sub-queries).
- Correct update semantics: a later SRV host/port, TXT, or address change re-emits the updated entry (a later yield supersedes the earlier for the same instance); a retarget drops the old host's addresses; SRV port 0 is treated as valid; names the `Name` type cannot represent faithfully are skipped, not corrupted.

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] Resolver unit tests: aggregation, instance/host/address caps, shared-host ordering, late-address re-emit, SRV/TXT re-emit, SRV retarget, SRV port 0, drop accounting
- [x] `loopback_lookup` integration suite — browse → resolve end-to-end over multicast loopback, stable across repeated runs
- [x] Full `agnostic-mdns` suite green (45 unit + 7 loopback + 3 smoke)
- [x] Converged through an 8-round Codex adversarial review (R1–R7 findings fixed; R8 found no issues)