### PR TITLE
Add resolve_host and resolve_instance conveniences

### DIFF
--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -561,66 +561,13 @@ impl LookupDriver {
   /// Feed one answer to the resolver, launch any follow-up queries it requests,
   /// then flush newly-resolved entries to the consumer.
   async fn process(&mut self, tagged: Tagged) {
-    for start in self.feed(tagged) {
+    for start in feed(&mut self.resolver, tagged) {
       // Launch inline. If the handle was dropped mid-launch the `start_query`
       // round-trip still completes promptly (the main driver replies regardless),
       // and the next loop iteration's `cancel` arm stops the task.
       self.launch(start).await;
     }
     self.flush();
-  }
-
-  /// Decode `tagged`, feed the resolver, and return the follow-up queries.
-  fn feed(&mut self, tagged: Tagged) -> Vec<Start> {
-    let answer = match tagged.event {
-      QueryEvent::Answer(a) => a,
-      QueryEvent::Terminal(_) => return Vec::new(),
-    };
-    match tagged.step {
-      Step::Ptr => {
-        if answer.rtype() != ResourceType::Ptr {
-          return Vec::new();
-        }
-        match parse_name(answer.rdata_slice()) {
-          Some(instance) => self.resolver.on_ptr(instance),
-          None => Vec::new(),
-        }
-      }
-      Step::Srv(inst_key) => {
-        if answer.rtype() != ResourceType::Srv {
-          return Vec::new();
-        }
-        match parse_srv(answer.rdata_slice()) {
-          Some((host, port)) => self.resolver.on_srv(&inst_key, host, port),
-          None => Vec::new(),
-        }
-      }
-      Step::Txt(inst_key) => {
-        if answer.rtype() != ResourceType::Txt {
-          return Vec::new();
-        }
-        self
-          .resolver
-          .on_txt(&inst_key, parse_txt(answer.rdata_slice()));
-        Vec::new()
-      }
-      Step::A(host_key) => {
-        if let Ok(r) = ARecord::try_from_rdata(answer.rdata_slice()) {
-          if answer.rtype() == ResourceType::A {
-            self.resolver.on_addr(&host_key, IpAddr::V4(r.addr()));
-          }
-        }
-        Vec::new()
-      }
-      Step::Aaaa(host_key) => {
-        if let Ok(r) = AaaaRecord::try_from_rdata(answer.rdata_slice()) {
-          if answer.rtype() == ResourceType::Aaaa {
-            self.resolver.on_addr(&host_key, IpAddr::V6(r.addr()));
-          }
-        }
-        Vec::new()
-      }
-    }
   }
 
   /// Total observable drops surfaced via [`Lookup::dropped`]: instances refused
@@ -765,6 +712,162 @@ impl Endpoint {
     self
       .browse(QueryParam::new(service).with_timeout(timeout))
       .await
+  }
+
+  /// Resolve a host name to its addresses via mDNS A / AAAA queries (RFC 6762),
+  /// without the DNS-SD browse/resolve chain.
+  ///
+  /// Issues both queries and collects every advertised address for the
+  /// `timeout` window (the answer window for multicast responses), returning
+  /// them IPv4 first then IPv6, deduplicated and capped per family. The result
+  /// is empty if nothing answers. Unlike [`Self::resolve_instance`] this does
+  /// not require — or interpret — DNS-SD records; it is the multicast analogue
+  /// of resolving a hostname.
+  pub async fn resolve_host(
+    &self,
+    host: Name,
+    timeout: Duration,
+  ) -> Result<Vec<IpAddr>, StartQueryError> {
+    let host_key = fold(&host);
+    let a = self
+      .start_query(QuerySpec::new(host.clone(), ResourceType::A).with_timeout(timeout))
+      .await?;
+    let aaaa = self
+      .start_query(QuerySpec::new(host, ResourceType::Aaaa).with_timeout(timeout))
+      .await?;
+    let mut streams = SelectAll::new();
+    streams.push(tagged_stream(a, Step::A(host_key.clone())));
+    streams.push(tagged_stream(aaaa, Step::Aaaa(host_key)));
+
+    // Drive both queries to their terminal (the timeout), gathering addresses.
+    // The consumer here is this future itself, so the streams drain promptly.
+    let mut ipv4: Vec<Ipv4Addr> = Vec::new();
+    let mut ipv6: Vec<Ipv6Addr> = Vec::new();
+    while let Some(tagged) = streams.next().await {
+      let ans = match tagged.event {
+        QueryEvent::Answer(a) => a,
+        QueryEvent::Terminal(_) => continue,
+      };
+      match ans.rtype() {
+        ResourceType::A => {
+          if let Ok(r) = ARecord::try_from_rdata(ans.rdata_slice()) {
+            push_capped(&mut ipv4, r.addr());
+          }
+        }
+        ResourceType::Aaaa => {
+          if let Ok(r) = AaaaRecord::try_from_rdata(ans.rdata_slice()) {
+            push_capped(&mut ipv6, r.addr());
+          }
+        }
+        _ => {}
+      }
+    }
+    Ok(
+      ipv4
+        .into_iter()
+        .map(IpAddr::V4)
+        .chain(ipv6.into_iter().map(IpAddr::V6))
+        .collect(),
+    )
+  }
+
+  /// Resolve a *known* DNS-SD service instance directly into a [`ServiceEntry`],
+  /// skipping the PTR browse step (e.g.
+  /// `Name::try_from_str("Office._ipp._tcp.local.")`).
+  ///
+  /// Issues SRV + TXT for the instance and A / AAAA for the SRV target host, and
+  /// returns the first complete resolution — host + port, TXT, and at least one
+  /// address — or `None` if it does not complete within `timeout`. Use
+  /// [`Self::browse`] instead when the instance names are not known in advance.
+  pub async fn resolve_instance(
+    &self,
+    instance: Name,
+    timeout: Duration,
+  ) -> Result<Option<ServiceEntry>, StartQueryError> {
+    let mut resolver = Resolver::new(1);
+    let mut streams = SelectAll::new();
+    // Seed the resolver with the instance and issue its SRV + TXT (no PTR).
+    for start in resolver.on_ptr(instance) {
+      streams.push(self.launch_resolve(start, timeout).await?);
+    }
+    // Drive inline until the instance completes or every sub-query times out.
+    while let Some(tagged) = streams.next().await {
+      for start in feed(&mut resolver, tagged) {
+        streams.push(self.launch_resolve(start, timeout).await?);
+      }
+      if let Some(entry) = resolver.take_ready() {
+        return Ok(Some(entry));
+      }
+    }
+    Ok(resolver.take_ready())
+  }
+
+  /// Start a resolve sub-query and wrap it as a tagged stream. Used by the
+  /// one-shot resolve conveniences, which drive the merged streams inline rather
+  /// than via a spawned [`LookupDriver`].
+  async fn launch_resolve(
+    &self,
+    start: Start,
+    timeout: Duration,
+  ) -> Result<futures::stream::BoxStream<'static, Tagged>, StartQueryError> {
+    let qtype = start.qtype();
+    let query = self
+      .start_query(QuerySpec::new(start.name, qtype).with_timeout(timeout))
+      .await?;
+    Ok(tagged_stream(query, start.step))
+  }
+}
+
+/// Decode one tagged answer, fold it into `resolver`, and return any follow-up
+/// queries it requests. Shared by the streaming [`LookupDriver`] and the
+/// one-shot [`Endpoint::resolve_instance`] convenience.
+fn feed(resolver: &mut Resolver, tagged: Tagged) -> Vec<Start> {
+  let answer = match tagged.event {
+    QueryEvent::Answer(a) => a,
+    QueryEvent::Terminal(_) => return Vec::new(),
+  };
+  match tagged.step {
+    Step::Ptr => {
+      if answer.rtype() != ResourceType::Ptr {
+        return Vec::new();
+      }
+      match parse_name(answer.rdata_slice()) {
+        Some(instance) => resolver.on_ptr(instance),
+        None => Vec::new(),
+      }
+    }
+    Step::Srv(inst_key) => {
+      if answer.rtype() != ResourceType::Srv {
+        return Vec::new();
+      }
+      match parse_srv(answer.rdata_slice()) {
+        Some((host, port)) => resolver.on_srv(&inst_key, host, port),
+        None => Vec::new(),
+      }
+    }
+    Step::Txt(inst_key) => {
+      if answer.rtype() != ResourceType::Txt {
+        return Vec::new();
+      }
+      resolver.on_txt(&inst_key, parse_txt(answer.rdata_slice()));
+      Vec::new()
+    }
+    Step::A(host_key) => {
+      if let Ok(r) = ARecord::try_from_rdata(answer.rdata_slice()) {
+        if answer.rtype() == ResourceType::A {
+          resolver.on_addr(&host_key, IpAddr::V4(r.addr()));
+        }
+      }
+      Vec::new()
+    }
+    Step::Aaaa(host_key) => {
+      if let Ok(r) = AaaaRecord::try_from_rdata(answer.rdata_slice()) {
+        if answer.rtype() == ResourceType::Aaaa {
+          resolver.on_addr(&host_key, IpAddr::V6(r.addr()));
+        }
+      }
+      Vec::new()
+    }
   }
 }
 

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -37,7 +37,7 @@ use std::{
   collections::{HashMap, HashSet, VecDeque},
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
   sync::{Arc, Mutex, MutexGuard},
-  time::Duration,
+  time::{Duration, Instant},
 };
 
 use futures::{FutureExt, StreamExt, pin_mut, select_biased, stream::SelectAll};
@@ -784,16 +784,22 @@ impl Endpoint {
     instance: Name,
     timeout: Duration,
   ) -> Result<Option<ServiceEntry>, StartQueryError> {
+    // One deadline shared across stages: follow-up A/AAAA queries get the
+    // REMAINING budget, not a fresh full `timeout`, so the whole call stays
+    // bounded by `timeout` as documented (an SRV arriving late can't grant the
+    // address queries a second full window).
+    let deadline = Instant::now() + timeout;
+    let remaining = || deadline.saturating_duration_since(Instant::now());
     let mut resolver = Resolver::new(1);
     let mut streams = SelectAll::new();
     // Seed the resolver with the instance and issue its SRV + TXT (no PTR).
     for start in resolver.on_ptr(instance) {
-      streams.push(self.launch_resolve(start, timeout).await?);
+      streams.push(self.launch_resolve(start, remaining()).await?);
     }
     // Drive inline until the instance completes or every sub-query times out.
     while let Some(tagged) = streams.next().await {
       for start in feed(&mut resolver, tagged) {
-        streams.push(self.launch_resolve(start, timeout).await?);
+        streams.push(self.launch_resolve(start, remaining()).await?);
       }
       if let Some(entry) = resolver.take_ready() {
         return Ok(Some(entry));

--- a/agnostic-mdns/src/discovery.rs
+++ b/agnostic-mdns/src/discovery.rs
@@ -788,8 +788,12 @@ impl Endpoint {
     // REMAINING budget, not a fresh full `timeout`, so the whole call stays
     // bounded by `timeout` as documented (an SRV arriving late can't grant the
     // address queries a second full window).
-    let deadline = Instant::now() + timeout;
-    let remaining = || deadline.saturating_duration_since(Instant::now());
+    // `checked_add` so a pathological `timeout` (e.g. `Duration::MAX`) cannot
+    // panic the way `Instant + Duration` would. An overflow means "no effective
+    // deadline", so each stage just receives the full (huge) `timeout`, which
+    // `QuerySpec` clamps with its own checked arithmetic.
+    let deadline = Instant::now().checked_add(timeout);
+    let remaining = || deadline.map_or(timeout, |d| d.saturating_duration_since(Instant::now()));
     let mut resolver = Resolver::new(1);
     let mut streams = SelectAll::new();
     // Seed the resolver with the instance and issue its SRV + TXT (no PTR).

--- a/agnostic-mdns/tests/loopback_lookup.rs
+++ b/agnostic-mdns/tests/loopback_lookup.rs
@@ -82,22 +82,23 @@ struct LoopbackPair {
 /// responder publishing the canonical test service. The responder is given
 /// `setup_wait` to finish probing + announcing before the function returns.
 async fn build_pair(setup_wait: Duration) -> Option<LoopbackPair> {
-  build_pair_named(setup_wait, UNIQUE_INSTANCE, UNIQUE_HOST).await
+  build_pair_named(setup_wait, UNIQUE_SERVICE, UNIQUE_INSTANCE, UNIQUE_HOST).await
 }
 
-/// Like [`build_pair`] but with caller-chosen instance and host names. Tests
-/// that resolve a *specific* instance/host name (rather than browsing the type)
-/// pass unique names so concurrent tests cannot conflict-rename the record out
-/// from under them.
+/// Like [`build_pair`] but with a caller-chosen service type, instance, and host
+/// name. Tests that resolve a *specific* name (rather than browsing the shared
+/// type) pass unique values so they neither conflict-rename a shared record nor
+/// leak their instance into another test's browse results.
 async fn build_pair_named(
   setup_wait: Duration,
+  service: &str,
   instance: &str,
   host: &str,
 ) -> Option<LoopbackPair> {
   let idx = loopback_index()?;
 
   let responder = try_endpoint(loopback_opts(idx)).await?;
-  let stype = Name::try_from_str(UNIQUE_SERVICE).unwrap();
+  let stype = Name::try_from_str(service).unwrap();
   let instance = Name::try_from_str(instance).unwrap();
   let host = Name::try_from_str(host).unwrap();
   let mut recs = ServiceRecords::new(stype, instance, host, SERVICE_PORT, 120);
@@ -400,9 +401,13 @@ async fn loopback_resolve_host_returns_addresses() {
 /// can't conflict-rename them — this responder reliably owns the queried name.
 #[tokio::test]
 async fn loopback_resolve_instance_returns_entry() {
-  const INST: &str = "ResolveOne._agnostic-mdns-test-v06._tcp.local.";
+  // A dedicated service type (not UNIQUE_SERVICE) so this responder's PTR never
+  // appears in `loopback_browse_resolves_service_entry`, which would otherwise
+  // be able to pick this instance and then fail its UNIQUE_HOST assertion.
+  const SVC: &str = "_agnostic-mdns-resolve-v06._tcp.local.";
+  const INST: &str = "ResolveOne._agnostic-mdns-resolve-v06._tcp.local.";
   const HOST: &str = "resolve-one-host.local.";
-  let pair = match build_pair_named(Duration::from_millis(1300), INST, HOST).await {
+  let pair = match build_pair_named(Duration::from_millis(1300), SVC, INST, HOST).await {
     Some(p) => p,
     None => return,
   };

--- a/agnostic-mdns/tests/loopback_lookup.rs
+++ b/agnostic-mdns/tests/loopback_lookup.rs
@@ -18,7 +18,10 @@
 #![cfg(feature = "tokio")]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use std::{net::Ipv6Addr, time::Duration};
+use std::{
+  net::{IpAddr, Ipv6Addr},
+  time::Duration,
+};
 
 use agnostic_mdns::{
   CollectedAnswer, Name, QueryEvent, QueryParam, QuerySpec, ServerOptions, Service, ServiceRecords,
@@ -79,12 +82,24 @@ struct LoopbackPair {
 /// responder publishing the canonical test service. The responder is given
 /// `setup_wait` to finish probing + announcing before the function returns.
 async fn build_pair(setup_wait: Duration) -> Option<LoopbackPair> {
+  build_pair_named(setup_wait, UNIQUE_INSTANCE, UNIQUE_HOST).await
+}
+
+/// Like [`build_pair`] but with caller-chosen instance and host names. Tests
+/// that resolve a *specific* instance/host name (rather than browsing the type)
+/// pass unique names so concurrent tests cannot conflict-rename the record out
+/// from under them.
+async fn build_pair_named(
+  setup_wait: Duration,
+  instance: &str,
+  host: &str,
+) -> Option<LoopbackPair> {
   let idx = loopback_index()?;
 
   let responder = try_endpoint(loopback_opts(idx)).await?;
   let stype = Name::try_from_str(UNIQUE_SERVICE).unwrap();
-  let instance = Name::try_from_str(UNIQUE_INSTANCE).unwrap();
-  let host = Name::try_from_str(UNIQUE_HOST).unwrap();
+  let instance = Name::try_from_str(instance).unwrap();
+  let host = Name::try_from_str(host).unwrap();
   let mut recs = ServiceRecords::new(stype, instance, host, SERVICE_PORT, 120);
   recs.add_a(ADVERTISED_V4.into());
   recs.add_aaaa(ADVERTISED_V6);
@@ -340,6 +355,93 @@ async fn loopback_browse_resolves_service_entry() {
     "expected {ADVERTISED_V4:?} in {:?}",
     entry.ipv4_addresses()
   );
+  assert!(
+    entry
+      .txt()
+      .iter()
+      .any(|t| t.as_slice() == b"Local web server"),
+    "expected TXT 'Local web server' in {:?}",
+    entry.txt()
+  );
+}
+
+/// `resolve_host`: plain mDNS hostname resolution (A/AAAA), no DNS-SD chain. The
+/// host name carries identical A rdata across any concurrent responders, so this
+/// is robust under parallel tests (no §9 conflict on shared, identical records).
+#[tokio::test]
+async fn loopback_resolve_host_returns_addresses() {
+  let pair = match build_pair(Duration::from_millis(1300)).await {
+    Some(p) => p,
+    None => return,
+  };
+  let addrs = match pair
+    .querier
+    .resolve_host(
+      Name::try_from_str(UNIQUE_HOST).unwrap(),
+      Duration::from_secs(2),
+    )
+    .await
+  {
+    Ok(a) => a,
+    Err(e) => {
+      eprintln!("skipping: resolve_host failed: {e:?}");
+      return;
+    }
+  };
+  eprintln!("resolve_host: {addrs:?}");
+  assert!(
+    addrs.contains(&IpAddr::V4(ADVERTISED_V4.into())),
+    "expected {ADVERTISED_V4:?} in {addrs:?}"
+  );
+}
+
+/// `resolve_instance`: resolve a *known* instance directly (SRV/TXT + A/AAAA),
+/// skipping the PTR browse. Uses unique instance/host names so a concurrent test
+/// can't conflict-rename them — this responder reliably owns the queried name.
+#[tokio::test]
+async fn loopback_resolve_instance_returns_entry() {
+  const INST: &str = "ResolveOne._agnostic-mdns-test-v06._tcp.local.";
+  const HOST: &str = "resolve-one-host.local.";
+  let pair = match build_pair_named(Duration::from_millis(1300), INST, HOST).await {
+    Some(p) => p,
+    None => return,
+  };
+  let resolved = tokio::time::timeout(
+    Duration::from_secs(6),
+    pair
+      .querier
+      .resolve_instance(Name::try_from_str(INST).unwrap(), Duration::from_secs(2)),
+  )
+  .await;
+  let entry = match resolved {
+    Ok(Ok(Some(e))) => e,
+    other => panic!("resolve_instance did not resolve {INST}: {other:?}"),
+  };
+  eprintln!(
+    "resolve_instance: host={} port={} v4={:?} v6={:?}",
+    entry.host(),
+    entry.port(),
+    entry.ipv4_addresses(),
+    entry.ipv6_addresses()
+  );
+  assert_eq!(entry.port(), SERVICE_PORT, "wrong port");
+  assert!(
+    entry.host().as_str().eq_ignore_ascii_case(HOST),
+    "wrong host: {}",
+    entry.host()
+  );
+  // First complete resolution carries >= 1 address; family/order isn't fixed on
+  // loopback, so assert presence + that every address is one we advertised.
+  assert!(
+    entry.addresses().next().is_some(),
+    "expected at least one address"
+  );
+  for a in entry.addresses() {
+    assert!(
+      a == IpAddr::V4(ADVERTISED_V4.into()) || a == IpAddr::V6(ADVERTISED_V6),
+      "unexpected address {a}"
+    );
+  }
   assert!(
     entry
       .txt()


### PR DESCRIPTION
## Summary

Two one-shot resolve helpers on `Endpoint`, layered on the same `start_query` primitive and `Resolver` aggregation as `browse()`, for the common cases that don't need a full DNS-SD browse:

- **`resolve_host(name, timeout) -> Vec<IpAddr>`** — plain mDNS A/AAAA hostname resolution (RFC 6762), no DNS-SD chain. Collects every advertised address over the `timeout` window, IPv4 first then IPv6, deduplicated and capped per family; empty if nothing answers.
- **`resolve_instance(name, timeout) -> Option<ServiceEntry>`** — resolve a *known* DNS-SD instance directly (SRV/TXT + A/AAAA on the target host), skipping the PTR browse; returns the first complete resolution, or `None` if it doesn't complete within `timeout`.

Both drive their merged sub-query streams inline (the awaiting caller is the consumer, so no spawned driver is needed — unlike the long-lived `Lookup`). The answer-decode step was extracted into a shared free `feed(resolver, tagged)` reused by the streaming `LookupDriver` and the one-shot `resolve_instance`, so there's no duplicated parsing logic.

`resolve_instance` enforces a single shared deadline across stages (follow-up address queries get the remaining budget, keeping the call bounded by `timeout`), computed with `checked_add` so a pathological `Duration::MAX` can't panic.

## Test plan

- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] New loopback integration tests: `resolve_host` (addresses) and `resolve_instance` (full `ServiceEntry`), the latter under its own service type so it can't interfere with the parallel browse test
- [x] Full `agnostic-mdns` suite green (45 unit + 9 loopback + 3 smoke), loopback stable across repeats
- [x] Converged through a 4-round Codex adversarial review (R1 test isolation, R2 timeout deadline, R3 overflow guard; R4 found no blocking issues)