### PR TITLE
feat(compio): mdns-compio — compio-native async mDNS (responder + querier + DNS-SD discovery)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
-members = ["mdns-proto", "mdns-udp", "mdns-reactor"]
+members = ["mdns-proto", "mdns-udp", "mdns-reactor", "mdns-compio"]
 resolver = "3"
-
 
 [workspace.dependencies]
 mdns-proto = { version = "0.5", path = "mdns-proto", default-features = false }
 mdns-udp = { version = "0.5", path = "mdns-udp", default-features = false }
-mdns-reactor = { version = "0.5", path = "mdns-reactor", default-features = false }
+mdns-reactor = { version = "0.6", path = "mdns-reactor", default-features = false }
+mdns-compio = { version = "0.1", path = "mdns-compio", default-features = false }

--- a/mdns-compio/Cargo.toml
+++ b/mdns-compio/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "mdns-compio"
+version = "0.1.0"
+edition = "2024"
+publish = true
+repository = "https://github.com/al8n/agnostic-mdns"
+homepage = "https://github.com/al8n/agnostic-mdns"
+documentation = "https://docs.rs/mdns-compio"
+description = "compio-native async mDNS driver (responder + querier + DNS-SD discovery), thread-per-core."
+license = "MIT OR Apache-2.0"
+rust-version = "1.85.0"
+categories = ["network-programming", "asynchronous"]
+keywords = ["mdns", "dns-sd", "zeroconf", "compio"]
+readme = "README.md"
+
+[features]
+default = []
+tracing = ["mdns-proto/tracing"]
+
+[dependencies]
+mdns-proto = { workspace = true, features = ["std", "slab"] }
+mdns-udp = { workspace = true }
+compio = { version = "0.18.0", features = ["time"] }
+compio-net = "0.11.1"
+compio-io = "0.9.1"
+compio-runtime = "0.11.0"
+compio-buf = "0.8"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+event-listener = "5"
+getifs = "0.6"
+slab = "0.4"
+rand = "0.10"
+thiserror = "2"
+tracing = "0.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+compio = { version = "0.18.0", features = ["macros", "time"] }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+rust_2018_idioms = "warn"
+single_use_lifetimes = "warn"

--- a/mdns-compio/README.md
+++ b/mdns-compio/README.md
@@ -1,0 +1,27 @@
+# mdns-compio
+
+compio-native async mDNS — responder + querier + DNS-SD discovery.
+Thread-per-core, completion I/O. Layered on `mdns-proto` (Sans-I/O) and
+`mdns-udp` (multicast socket helpers).
+
+```ignore
+use mdns_compio::{Endpoint, ServerOptions};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let endpoint = Endpoint::server(ServerOptions::default()).await?;
+# Ok(()) }
+```
+
+## Design
+
+- `!Send` throughout: no `Arc`, no `Mutex`, no atomics, no MPSC channels.
+- One spawned driver future per endpoint, owning the compio `UdpSocket`(s) and
+  pumping a `select!` over two in-flight `recv_msg`s (v4 + v6), a `sleep_until`
+  timer, and `LocalNotify`.
+- Handles (`Query`, `Service`, `Lookup`) hold `Rc<EndpointInner>` and borrow
+  shared state directly under short non-`.await` borrows.
+
+## Pinned versions
+
+`compio 0.18.0`, `compio-net 0.11.1`, `compio-io 0.9.1`, `compio-runtime 0.11.0`.
+No `rc` dependencies.

--- a/mdns-compio/build.rs
+++ b/mdns-compio/build.rs
@@ -1,0 +1,76 @@
+//! Emits capability `cfg`s for the receive-side ancillary (cmsg) features
+//! mdns-compio uses, so the per-function `#[cfg]`s reference ONE central
+//! availability matrix instead of hand-maintained `target_os` lists (which
+//! repeatedly drifted out of sync with what `libc` actually defines).
+//!
+//! This matrix is kept identical to `mdns-udp/build.rs` on purpose: both crates
+//! decode the same cmsg families against the same `libc` constants, so sharing
+//! one matrix (down to the emitted cfg names) keeps the two recv paths in step.
+//!
+//! Supported targets are capped by the `getifs` dependency (linux/android,
+//! apple, freebsd/dragonfly, openbsd/netbsd, windows); illumos/solaris/fuchsia
+//! and other Unixes are intentionally out of scope and get none of these cfgs.
+//!
+//! Capability → enabling libc constants (verified against libc 0.2):
+//!   * has_ip_pktinfo     IP_PKTINFO / IP_RECVPKTINFO (+ in_pktinfo parse)
+//!   * has_ipv6_pktinfo   IPV6_PKTINFO + IPV6_RECVPKTINFO
+//!   * has_recv_hoplimit  IP_RECVTTL + IPV6_HOPLIMIT + IPV6_RECVHOPLIMIT (§11)
+//!   * has_recv_timestamp SO_TIMESTAMP[NS] + SCM_TIMESTAMP[NS]
+//!   * recv_timestamp_ns  the timestamp cmsg is nanosecond SO_TIMESTAMPNS
+//!     (Linux/Android); otherwise it is microsecond SO_TIMESTAMP.
+
+fn main() {
+  println!("cargo:rerun-if-changed=build.rs");
+
+  // Declare every cfg we may emit so the `unexpected_cfgs` lint (the crate
+  // builds under `-D warnings`) recognises them whether or not they fire.
+  for name in [
+    "has_ip_pktinfo",
+    "has_ipv6_pktinfo",
+    "has_recv_hoplimit",
+    "has_recv_timestamp",
+    "recv_timestamp_ns",
+  ] {
+    println!("cargo::rustc-check-cfg=cfg({name})");
+  }
+
+  let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+  let vendor = std::env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or_default();
+
+  // Target families (mirrors getifs' own grouping). `target_vendor = "apple"`
+  // covers macos/ios/tvos/watchos/visionos uniformly.
+  let apple = vendor == "apple";
+  let linux_like = os == "linux" || os == "android";
+  let freebsdlike = os == "freebsd" || os == "dragonfly";
+  let netbsdlike = os == "openbsd" || os == "netbsd";
+
+  // IPv4 PKTINFO: only Linux/Android/Apple, which share the 12-byte in_pktinfo
+  // layout (ipi_ifindex / ipi_spec_dst / ipi_addr) that the v4 decoder reads.
+  // The BSDs are excluded: FreeBSD/OpenBSD/DragonFly have no IP_PKTINFO at all,
+  // and NetBSD's in_pktinfo is a DIFFERENT 8-byte layout (ipi_addr /
+  // ipi_ifindex) the shared parser would misread as too-short. All of them
+  // degrade to an unspecified local address + interface index 0, exactly as the
+  // IPv4 path already does elsewhere.
+  if linux_like || apple {
+    println!("cargo::rustc-cfg=has_ip_pktinfo");
+  }
+  // IPv6 PKTINFO: every supported Unix defines both IPV6_PKTINFO and
+  // IPV6_RECVPKTINFO.
+  if linux_like || apple || freebsdlike || netbsdlike {
+    println!("cargo::rustc-cfg=has_ipv6_pktinfo");
+  }
+  // RFC 6762 §11 TTL/Hop-Limit receive cmsg. Absent on netbsdlike
+  // (OpenBSD/NetBSD don't define IP_RECVTTL/IPV6_HOPLIMIT/IPV6_RECVHOPLIMIT).
+  if linux_like || apple || freebsdlike {
+    println!("cargo::rustc-cfg=has_recv_hoplimit");
+  }
+  // Kernel receive-timestamp cmsg (all supported Unix).
+  if linux_like || apple || freebsdlike || netbsdlike {
+    println!("cargo::rustc-cfg=has_recv_timestamp");
+  }
+  // Linux/Android deliver nanosecond SO_TIMESTAMPNS; the BSDs/Apple deliver
+  // microsecond SO_TIMESTAMP.
+  if linux_like {
+    println!("cargo::rustc-cfg=recv_timestamp_ns");
+  }
+}

--- a/mdns-compio/src/discovery.rs
+++ b/mdns-compio/src/discovery.rs
@@ -1,92 +1,68 @@
-//! DNS-SD service discovery — browse a service type and resolve each instance
-//! into a fully-populated [`ServiceEntry`].
+//! DNS-SD service discovery — data types and parsing helpers.
 //!
-//! This is the high-level client layer over [`Endpoint::start_query`]. A
-//! [`Lookup`] performs the RFC 6763 browse → resolve chain:
-//!
-//! 1. **Browse** (§4.1): a PTR query for the service type
-//!    (`_service._proto.local.`) yields the names of the published instances.
-//! 2. **Resolve** (§5): for each instance, an SRV query gives the target host
-//!    and port and a TXT query gives the metadata.
-//! 3. **Address** (§5): A / AAAA queries against the SRV target host give the
-//!    reachable addresses.
-//!
-//! An instance is surfaced as a [`ServiceEntry`] once it has a port (SRV), TXT
-//! data, and at least one address. Each step is a real [`crate::Query`], so
-//! retransmission, caching, and TTL handling are inherited from the
-//! proto/driver layers; the whole lookup is bounded by the per-query timeouts
-//! and by [`QueryParam::with_max_entries`], and is cancelled by dropping the
-//! [`Lookup`].
-//!
-//! # Design
-//!
-//! Modeled on quinn's `ConnectionDriver`: a spawned [`LookupDriver`] task owns
-//! the browse/resolve sub-queries and the aggregation state machine, and pushes
-//! resolved entries into shared state ([`LookupQueue`]) that the [`Lookup`]
-//! handle drains — mirroring the [`crate::Query`] mailbox/doorbell split. Driving
-//! the aggregation in its own task (rather than only while the caller awaits
-//! [`Lookup::next`]) means the sub-query mailboxes are drained promptly, so a
-//! slow consumer cannot stall resolution; the shared queue stays bounded by
-//! coalescing repeated snapshots of an instance.
-//!
-//! Instance/host names that the [`Name`] type cannot represent faithfully — a
-//! label containing a `.` or a non-ASCII byte — are skipped rather than
-//! silently corrupted (`Name` is an ASCII, dot-separated, no-escaping type).
+//! This module hosts the public types ([`ServiceEntry`], [`QueryParam`]) and the
+//! crate-internal helpers (`push_capped`, `fold`, `parse_name`,
+//! `parse_srv`, `parse_txt`, `name_from_ref`) that the resolver state
+//! machine and [`Lookup`] handle build on. The
+//! [`Endpoint::browse`](crate::Endpoint::browse) /
+//! [`lookup`](crate::Endpoint::lookup) /
+//! [`resolve_host`](crate::Endpoint::resolve_host) /
+//! [`resolve_instance`](crate::Endpoint::resolve_instance) APIs wire these
+//! together to drive the RFC 6763 browse → resolve chain.
 
-use std::{
-  collections::{HashMap, HashSet, VecDeque},
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use core::{
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
-  sync::{Arc, Mutex, MutexGuard},
-  time::{Duration, Instant},
+  time::Duration,
 };
 
-use futures::{FutureExt, StreamExt, pin_mut, select_biased, stream::SelectAll};
+use futures::future::select_all;
 use mdns_proto::{
   Name, QuerySpec,
   wire::{ARecord, AaaaRecord, NameRef, PtrRecord, ResourceType, SrvRecord, TxtRecord},
 };
 
 use crate::{
-  Endpoint, QueryEvent,
-  error::StartQueryError,
-  query::{DroppedHandle, Query},
+  endpoint::Endpoint,
+  query::{Query, QueryEvent},
 };
 
-/// Default cap on the number of distinct instances a [`Lookup`] tracks, so a
-/// chatty or hostile responder flooding PTR answers cannot grow the builder map
-/// or the in-flight sub-query set without bound.
+/// Default cap on the number of distinct instances a lookup tracks, so a chatty
+/// or hostile responder flooding PTR answers cannot grow the in-progress state
+/// without bound. Used by [`QueryParam::new`].
 pub const DEFAULT_MAX_ENTRIES: usize = 64;
 
 /// Cap on the addresses kept per host per family (and per instance), so a
 /// responder flooding distinct A/AAAA records for one host cannot grow the
-/// address vectors (in the host cache or any builder) without bound.
-const MAX_ADDRS_PER_HOST: usize = 16;
+/// address vectors without limit.
+pub(crate) const MAX_ADDRS_PER_HOST: usize = 16;
 
 /// A resolved DNS-SD service instance.
 ///
-/// Produced by [`Lookup::next`] once the instance's SRV (host + port), TXT, and
-/// at least one address have been collected.
+/// Produced by the resolver once the instance has SRV (host + port), TXT, and
+/// at least one address.
 #[derive(Debug, Clone)]
 pub struct ServiceEntry {
-  instance: Name,
-  host: Name,
-  port: u16,
-  ipv4: Vec<Ipv4Addr>,
-  ipv6: Vec<Ipv6Addr>,
-  txt: Vec<Vec<u8>>,
+  pub(crate) instance: Name,
+  pub(crate) host: Name,
+  pub(crate) port: u16,
+  pub(crate) ipv4: Vec<Ipv4Addr>,
+  pub(crate) ipv6: Vec<Ipv6Addr>,
+  pub(crate) txt: Vec<Vec<u8>>,
 }
 
 impl ServiceEntry {
   /// The fully-qualified service instance name (the PTR target), e.g.
   /// `myprinter._ipp._tcp.local.`.
   #[inline]
-  pub fn instance_name(&self) -> &Name {
+  pub const fn instance_name(&self) -> &Name {
     &self.instance
   }
 
   /// The target host the SRV record points at, e.g. `printer.local.`.
   #[inline]
-  pub fn host(&self) -> &Name {
+  pub const fn host(&self) -> &Name {
     &self.host
   }
 
@@ -127,14 +103,14 @@ impl ServiceEntry {
   }
 }
 
-/// Parameters for a [`Lookup`] / browse.
+/// Parameters for a DNS-SD browse / lookup.
 #[derive(Debug, Clone)]
 pub struct QueryParam {
-  service: Name,
-  timeout: Duration,
-  resolve_timeout: Option<Duration>,
-  unicast_response: bool,
-  max_entries: usize,
+  pub(crate) service: Name,
+  pub(crate) timeout: Duration,
+  pub(crate) resolve_timeout: Option<Duration>,
+  pub(crate) unicast_response: bool,
+  pub(crate) max_entries: usize,
 }
 
 impl QueryParam {
@@ -158,7 +134,7 @@ impl QueryParam {
   }
 
   /// How long each per-instance resolve query (SRV / TXT / A / AAAA) runs.
-  /// Defaults to the browse timeout.
+  /// Defaults to the browse timeout when unset.
   #[must_use]
   pub const fn with_resolve_timeout(mut self, timeout: Duration) -> Self {
     self.resolve_timeout = Some(timeout);
@@ -174,8 +150,8 @@ impl QueryParam {
   }
 
   /// Cap on the number of distinct instances tracked; instances discovered
-  /// beyond it are dropped (counted by [`Lookup::dropped`]). Defaults to
-  /// [`DEFAULT_MAX_ENTRIES`]. A value of `0` is treated as `1`.
+  /// beyond it are dropped. Defaults to [`DEFAULT_MAX_ENTRIES`]. A value of
+  /// `0` is treated as `1`.
   #[must_use]
   pub const fn with_max_entries(mut self, max: usize) -> Self {
     self.max_entries = if max == 0 { 1 } else { max };
@@ -183,10 +159,81 @@ impl QueryParam {
   }
 }
 
+/// Push `item` into `v` if it is new (by equality) and `v` is still under
+/// [`MAX_ADDRS_PER_HOST`]. Returns `true` if it was added (so the caller can
+/// decide to (re)emit), `false` if it was a duplicate or the cap was reached.
+pub(crate) fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
+  if v.len() >= MAX_ADDRS_PER_HOST || v.contains(&item) {
+    return false;
+  }
+  v.push(item);
+  true
+}
+
+/// Case-fold a [`Name`] to its lookup key. DNS names are case-insensitive
+/// (RFC 6762 §16), so the lower-cased string form is the canonical key for
+/// the resolver's per-instance / per-host maps.
+pub(crate) fn fold(name: &Name) -> String {
+  name.as_str().to_ascii_lowercase()
+}
+
+/// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
+/// stored in a [`mdns_proto::CollectedAnswer`]) into an owned [`Name`].
+///
+/// Returns `None` for any name the [`Name`] type cannot represent faithfully:
+/// a label containing a `.` (which is always treated as a separator by
+/// [`Name`]) or a non-ASCII byte. Such inputs are skipped rather than silently
+/// corrupted.
+fn name_from_ref(nr: &NameRef<'_>) -> Option<Name> {
+  let mut buf = String::new();
+  for label in nr.labels() {
+    let label = label.ok()?;
+    if label.is_empty() {
+      break; // root terminator
+    }
+    if label.iter().any(|&b| b >= 0x80 || b == b'.') {
+      return None; // not representable by `Name` without corruption
+    }
+    // Verified ASCII above, so this slice is always valid UTF-8.
+    buf.push_str(core::str::from_utf8(label).ok()?);
+    buf.push('.');
+  }
+  if buf.is_empty() {
+    return None;
+  }
+  Name::try_from_str(&buf).ok()
+}
+
+/// Parse a PTR rdata slice (a decompressed wire-form name) into a [`Name`].
+/// Returns `None` for a malformed or unrepresentable target.
+pub(crate) fn parse_name(rdata: &[u8]) -> Option<Name> {
+  let ptr = PtrRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
+  name_from_ref(ptr.target())
+}
+
+/// Parse an SRV rdata slice into `(target host, port)`. Returns `None` for a
+/// malformed record or an unrepresentable target host name.
+pub(crate) fn parse_srv(rdata: &[u8]) -> Option<(Name, u16)> {
+  let srv = SrvRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
+  let host = name_from_ref(srv.target())?;
+  Some((host, srv.port()))
+}
+
+/// Parse a TXT rdata slice into its length-prefixed segments
+/// (RFC 1035 §3.3.14 + RFC 6763 §6). Drops a malformed tail rather than
+/// failing the whole record.
+pub(crate) fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
+  TxtRecord::from_rdata(rdata)
+    .segments()
+    .map_while(Result::ok)
+    .map(<[u8]>::to_vec)
+    .collect()
+}
+
 /// Which resolve step an answer belongs to. The string is the case-folded key
 /// of the owning instance (SRV/TXT) or host (A/AAAA).
 #[derive(Clone)]
-enum Step {
+pub(crate) enum Step {
   Ptr,
   Srv(String),
   Txt(String),
@@ -194,22 +241,16 @@ enum Step {
   Aaaa(String),
 }
 
-/// One answer, tagged with the resolve step that produced it.
-struct Tagged {
-  step: Step,
-  event: QueryEvent,
-}
-
 /// A follow-up query the driver should launch as a result of feeding the
 /// [`Resolver`] an answer.
 #[derive(Clone)]
-struct Start {
-  name: Name,
-  step: Step,
+pub(crate) struct Start {
+  pub(crate) name: Name,
+  pub(crate) step: Step,
 }
 
 impl Start {
-  const fn qtype(&self) -> ResourceType {
+  pub(crate) const fn qtype(&self) -> ResourceType {
     match self.step {
       Step::Srv(_) => ResourceType::Srv,
       Step::Txt(_) => ResourceType::Txt,
@@ -220,20 +261,29 @@ impl Start {
   }
 }
 
+/// Addresses already learned for a host, so a later instance whose SRV resolves
+/// to the same host picks them up even though the A/AAAA answer has come and
+/// gone (the shared-host, SRV-after-A ordering).
+#[derive(Default)]
+pub(crate) struct HostAddrs {
+  pub(crate) ipv4: Vec<Ipv4Addr>,
+  pub(crate) ipv6: Vec<Ipv6Addr>,
+}
+
 /// In-progress aggregation of one service instance.
-struct Builder {
-  instance: Name,
-  host: Option<Name>,
-  host_key: Option<String>,
+pub(crate) struct Builder {
+  pub(crate) instance: Name,
+  pub(crate) host: Option<Name>,
+  pub(crate) host_key: Option<String>,
   /// Whether an SRV record has been seen. Tracked separately from `port`
   /// because `0` is a valid SRV port (the full `u16` range is parsed and the
   /// registration API does not reject it), so it cannot double as a sentinel.
-  has_srv: bool,
-  port: u16,
-  ipv4: Vec<Ipv4Addr>,
-  ipv6: Vec<Ipv6Addr>,
-  txt: Option<Vec<Vec<u8>>>,
-  emitted: bool,
+  pub(crate) has_srv: bool,
+  pub(crate) port: u16,
+  pub(crate) ipv4: Vec<Ipv4Addr>,
+  pub(crate) ipv6: Vec<Ipv6Addr>,
+  pub(crate) txt: Option<Vec<Vec<u8>>>,
+  pub(crate) emitted: bool,
 }
 
 impl Builder {
@@ -268,35 +318,26 @@ impl Builder {
   }
 }
 
-/// Addresses already learned for a host, so a later instance whose SRV resolves
-/// to the same host picks them up even though the A/AAAA answer has come and
-/// gone (the shared-host, SRV-after-A ordering).
-#[derive(Default)]
-struct HostAddrs {
-  ipv4: Vec<Ipv4Addr>,
-  ipv6: Vec<Ipv6Addr>,
-}
-
-/// Pure browse/resolve aggregation state machine — no I/O. The [`LookupDriver`]
+/// Pure browse/resolve aggregation state machine — no I/O. The lookup driver
 /// feeds it parsed answers and launches the follow-up queries it requests.
-struct Resolver {
-  builders: HashMap<String, Builder>,
-  host_addrs: HashMap<String, HostAddrs>,
-  hosts_queried: HashSet<String>,
-  ready: VecDeque<ServiceEntry>,
+pub(crate) struct Resolver {
+  pub(crate) builders: HashMap<String, Builder>,
+  pub(crate) host_addrs: HashMap<String, HostAddrs>,
+  pub(crate) hosts_queried: HashSet<String>,
+  pub(crate) ready: VecDeque<ServiceEntry>,
   /// Cap on distinct instances tracked.
-  max_entries: usize,
+  pub(crate) max_entries: usize,
   /// Cap on distinct hosts A/AAAA-queried. Set equal to `max_entries`: honest
   /// browsing has at most one host per instance, so this never bites a real
   /// responder, but it bounds an instance that floods distinct SRV targets
   /// (which would otherwise grow `hosts_queried`/`host_addrs` and the in-flight
   /// A/AAAA sub-query set without limit).
-  max_hosts: usize,
-  dropped: u64,
+  pub(crate) max_hosts: usize,
+  pub(crate) dropped: u64,
 }
 
 impl Resolver {
-  fn new(max_entries: usize) -> Self {
+  pub(crate) fn new(max_entries: usize) -> Self {
     Self {
       builders: HashMap::new(),
       host_addrs: HashMap::new(),
@@ -310,7 +351,7 @@ impl Resolver {
 
   /// A newly discovered instance: register it (subject to the cap) and request
   /// its SRV + TXT resolves.
-  fn on_ptr(&mut self, instance: Name) -> Vec<Start> {
+  pub(crate) fn on_ptr(&mut self, instance: Name) -> Vec<Start> {
     let key = fold(&instance);
     if self.builders.contains_key(&key) {
       return Vec::new(); // already discovered
@@ -337,9 +378,12 @@ impl Resolver {
   /// An instance's SRV: record host + port, adopt any addresses already learned
   /// for that host, and request A/AAAA the first time we see the host — subject
   /// to the distinct-host cap, which bounds an SRV-target flood.
-  fn on_srv(&mut self, inst_key: &str, host: Name, port: u16) -> Vec<Start> {
+  pub(crate) fn on_srv(&mut self, inst_key: &str, host: Name, port: u16) -> Vec<Start> {
     let host_key = fold(&host);
-    let cached = self.host_addrs.get(&host_key);
+    let cached = self
+      .host_addrs
+      .get(&host_key)
+      .map(|h| (h.ipv4.clone(), h.ipv6.clone()));
     let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
       let host_changed = b.host_key.as_deref() != Some(host_key.as_str());
@@ -351,20 +395,20 @@ impl Resolver {
         b.ipv4.clear();
         b.ipv6.clear();
       }
-      // A host or port change to an already-surfaced instance must re-emit even
-      // when the new host's addresses are already cached — no fresh A/AAAA event
-      // will arrive to trigger the re-emit, so without this the consumer keeps a
-      // stale host/port.
+      // A host or port change to an already-surfaced instance must re-emit
+      // even when the new host's addresses are already cached — no fresh
+      // A/AAAA event will arrive to trigger the re-emit, so without this the
+      // consumer keeps a stale host/port.
       changed = host_changed || b.port != port;
       b.has_srv = true;
       b.host = Some(host.clone());
       b.host_key = Some(host_key.clone());
       b.port = port;
-      if let Some(addrs) = cached {
-        for &a in &addrs.ipv4 {
+      if let Some((v4, v6)) = cached {
+        for a in v4 {
           push_capped(&mut b.ipv4, a);
         }
-        for &a in &addrs.ipv6 {
+        for a in v6 {
           push_capped(&mut b.ipv6, a);
         }
       }
@@ -392,31 +436,28 @@ impl Resolver {
     ]
   }
 
-  fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
+  pub(crate) fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
     let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
       // A TXT change to an already-surfaced instance must re-emit so the
       // consumer sees the new metadata; a duplicate TXT must not (no spurious
-      // re-emit). First TXT flips this from `None`, driving the first emit once
-      // the instance is otherwise complete.
+      // re-emit on a refresh that carries the same payload).
       changed = b.txt.as_deref() != Some(segs.as_slice());
       b.txt = Some(segs);
     }
     self.try_emit(inst_key, changed);
   }
 
-  /// An A/AAAA answer for a host: cache it (capped) and apply it to every
-  /// instance whose SRV already pointed at that host. A newly-added address may
-  /// re-emit an already-surfaced instance with the fuller address set.
-  ///
-  /// Only called for a host we actually launched A/AAAA queries for (a step key
-  /// from a query we started), so `host_addrs` stays bounded by `hosts_queried`.
-  fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
+  pub(crate) fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
     let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
     match addr {
-      IpAddr::V4(a) => push_capped(&mut cache.ipv4, a),
-      IpAddr::V6(a) => push_capped(&mut cache.ipv6, a),
-    };
+      IpAddr::V4(a) => {
+        push_capped(&mut cache.ipv4, a);
+      }
+      IpAddr::V6(a) => {
+        push_capped(&mut cache.ipv6, a);
+      }
+    }
     let keys: Vec<String> = self
       .builders
       .iter()
@@ -437,170 +478,26 @@ impl Resolver {
     }
   }
 
-  /// Emit the instance if it is complete: the first time it completes, or — when
-  /// `allow_reemit` — again with an updated snapshot (e.g. a late AAAA after the
-  /// entry was first surfaced on its A address).
-  fn try_emit(&mut self, inst_key: &str, allow_reemit: bool) {
+  pub(crate) fn try_emit(&mut self, inst_key: &str, allow_reemit: bool) {
     if let Some(b) = self.builders.get_mut(inst_key) {
       if !b.complete() {
         return;
       }
       if !b.emitted {
-        if let Some(entry) = b.finalize() {
+        if let Some(e) = b.finalize() {
           b.emitted = true;
-          self.ready.push_back(entry);
+          self.ready.push_back(e);
         }
       } else if allow_reemit {
-        if let Some(entry) = b.finalize() {
-          self.ready.push_back(entry);
+        if let Some(e) = b.finalize() {
+          self.ready.push_back(e);
         }
       }
     }
   }
 
-  fn take_ready(&mut self) -> Option<ServiceEntry> {
+  pub(crate) fn take_ready(&mut self) -> Option<ServiceEntry> {
     self.ready.pop_front()
-  }
-}
-
-/// Bounded, instance-coalescing queue of resolved entries shared between the
-/// spawned [`LookupDriver`] (which fills it) and the [`Lookup`] handle (which
-/// drains it via [`Lookup::next`]). Mirrors the [`crate::Query`] mailbox.
-struct LookupQueue {
-  ready: VecDeque<ServiceEntry>,
-  /// Set once the driver task has finished (all sub-queries terminated, or the
-  /// handle was dropped). A drained-empty queue with `done` set is end-of-stream.
-  done: bool,
-  /// Snapshot of the resolver's drop counter, surfaced via [`Lookup::dropped`].
-  dropped: u64,
-}
-
-impl LookupQueue {
-  fn new() -> Self {
-    Self {
-      ready: VecDeque::new(),
-      done: false,
-      dropped: 0,
-    }
-  }
-
-  /// Enqueue a resolved entry, coalescing by instance so a slow consumer cannot
-  /// grow the queue past the live instance set: a newer snapshot for an instance
-  /// supersedes any still-pending one (matching the "later yield supersedes
-  /// earlier" contract on [`Lookup::next`]).
-  fn enqueue(&mut self, entry: ServiceEntry) {
-    if let Some(slot) = self
-      .ready
-      .iter_mut()
-      .find(|e| e.instance.as_str() == entry.instance.as_str())
-    {
-      *slot = entry;
-    } else {
-      self.ready.push_back(entry);
-    }
-  }
-}
-
-/// Lock the shared queue, recovering the guard if a previous holder panicked
-/// (the lock is never held across a fallible operation, so the data is sound).
-fn lock(q: &Mutex<LookupQueue>) -> MutexGuard<'_, LookupQueue> {
-  q.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-/// Spawned task that owns the browse/resolve sub-queries and the [`Resolver`],
-/// feeding resolved entries into the shared [`LookupQueue`]. Quinn's
-/// `ConnectionDriver`, scoped to a single lookup.
-struct LookupDriver {
-  endpoint: Endpoint,
-  streams: SelectAll<futures::stream::BoxStream<'static, Tagged>>,
-  resolver: Resolver,
-  /// Drop counter of the browse (PTR) query. Surplus instances evicted by the
-  /// PTR query's bounded answer pool before [`Resolver::on_ptr`] sees them are
-  /// counted here rather than in `resolver.dropped`; folding both into
-  /// [`Lookup::dropped`] keeps the partial-view signal complete.
-  ptr_drops: DroppedHandle,
-  queue: Arc<Mutex<LookupQueue>>,
-  /// Capacity-1 wakeup the consumer parks on; rung after the queue changes.
-  doorbell: async_channel::Sender<()>,
-  /// Closes when the [`Lookup`] handle is dropped, which stops the task and
-  /// (by dropping the sub-query [`Query`] handles) cancels every sub-query.
-  cancel: async_channel::Receiver<()>,
-  resolve_timeout: Duration,
-  unicast: bool,
-}
-
-impl LookupDriver {
-  async fn run(mut self) {
-    loop {
-      // Wait for the next answer or for the handle to be dropped. The futures
-      // borrow disjoint fields; act on `self` only after the select resolves
-      // (mirrors the main driver loop's borrow discipline).
-      let tagged = {
-        let next = self.streams.next().fuse();
-        let stop = self.cancel.recv().fuse();
-        pin_mut!(next, stop);
-        select_biased! {
-          _ = stop => None,   // handle dropped → stop
-          t = next => t,      // Some(answer), or None when all sub-queries end
-        }
-      };
-      match tagged {
-        Some(t) => self.process(t).await,
-        None => break,
-      }
-    }
-    // Signal end-of-stream and wake any parked consumer.
-    {
-      let mut q = lock(&self.queue);
-      q.done = true;
-      q.dropped = self.dropped_total();
-    }
-    let _ = self.doorbell.try_send(());
-  }
-
-  /// Feed one answer to the resolver, launch any follow-up queries it requests,
-  /// then flush newly-resolved entries to the consumer.
-  async fn process(&mut self, tagged: Tagged) {
-    for start in feed(&mut self.resolver, tagged) {
-      // Launch inline. If the handle was dropped mid-launch the `start_query`
-      // round-trip still completes promptly (the main driver replies regardless),
-      // and the next loop iteration's `cancel` arm stops the task.
-      self.launch(start).await;
-    }
-    self.flush();
-  }
-
-  /// Total observable drops surfaced via [`Lookup::dropped`]: instances refused
-  /// by the resolver caps plus surplus PTR answers the browse query's bounded
-  /// answer pool evicted before the resolver could see them (disjoint counts).
-  fn dropped_total(&self) -> u64 {
-    self.resolver.dropped.saturating_add(self.ptr_drops.get())
-  }
-
-  /// Move newly-resolved entries into the shared queue and wake the consumer.
-  fn flush(&mut self) {
-    let mut woke = false;
-    let mut q = lock(&self.queue);
-    while let Some(entry) = self.resolver.take_ready() {
-      q.enqueue(entry);
-      woke = true;
-    }
-    q.dropped = self.dropped_total();
-    drop(q);
-    if woke {
-      let _ = self.doorbell.try_send(());
-    }
-  }
-
-  /// Start a resolve sub-query and fold its answers into the merged stream.
-  async fn launch(&mut self, start: Start) {
-    let qtype = start.qtype();
-    let spec = QuerySpec::new(start.name, qtype)
-      .with_timeout(self.resolve_timeout)
-      .with_unicast_response(self.unicast);
-    if let Ok(query) = self.endpoint.start_query(spec).await {
-      self.streams.push(tagged_stream(query, start.step));
-    }
   }
 }
 
@@ -608,235 +505,97 @@ impl LookupDriver {
 ///
 /// Call [`Self::next`] to receive resolved [`ServiceEntry`] values as they
 /// complete; it returns `None` once every query (browse + resolves) has timed
-/// out. Resolution is driven by a spawned [`LookupDriver`] task, so it proceeds
-/// even between calls to `next`. Dropping the `Lookup` stops that task and
-/// cancels all of its in-flight queries.
+/// out and the resolver has drained.  Resolution progresses while
+/// [`Self::next`] is awaited — the lookup races the underlying sub-queries
+/// concurrently via [`futures::future::select_all`], so the first query with
+/// a buffered answer is processed without waiting on the others.
+///
+/// An instance may be yielded more than once as additional addresses resolve
+/// (e.g. a late AAAA after the entry was first surfaced on its A address); a
+/// later yield for the same [`ServiceEntry::instance_name`] supersedes the
+/// earlier one.  Dropping the `Lookup` cancels every in-flight sub-query.
 pub struct Lookup {
-  queue: Arc<Mutex<LookupQueue>>,
-  /// Capacity-1 wakeup the driver rings after filling the queue.
-  doorbell: async_channel::Receiver<()>,
-  /// Held only so dropping the `Lookup` closes the driver's `cancel` channel.
-  _cancel: async_channel::Sender<()>,
+  pub(crate) endpoint: Endpoint,
+  pub(crate) queries: Vec<(Query, Step)>,
+  pub(crate) resolver: Resolver,
+  pub(crate) resolve_timeout: Duration,
+  pub(crate) unicast: bool,
+  pub(crate) finished: bool,
 }
 
 impl Lookup {
-  /// Wait for the next resolved service instance, or `None` when the lookup is
-  /// finished (all queries timed out).
+  /// Wait for the next resolved service instance, or `None` when the lookup
+  /// is finished (every sub-query has terminated and the resolver has
+  /// drained).
   ///
-  /// An instance may be yielded more than once as additional addresses resolve
-  /// (e.g. a late AAAA after the entry was first surfaced on its A address); a
-  /// later yield for the same [`ServiceEntry::instance_name`] supersedes the
-  /// earlier one. Single-consumer: takes `&mut self`, so there is at most one
-  /// in-flight `next()` per `Lookup`, matching the single-waiter doorbell.
+  /// The borrow on `&mut self` matches the single-consumer mailbox contract
+  /// inherited from [`Query::next`]: at most one [`Self::next`] is in flight
+  /// per [`Lookup`].
   pub async fn next(&mut self) -> Option<ServiceEntry> {
     loop {
-      {
-        let mut q = lock(&self.queue);
-        if let Some(entry) = q.ready.pop_front() {
-          return Some(entry);
-        }
-        if q.done {
-          return None;
-        }
+      if let Some(e) = self.resolver.take_ready() {
+        return Some(e);
       }
-      // Nothing ready: park until the driver rings. A closed doorbell means the
-      // driver task exited — do one final drain (entries or the `done` flag it
-      // set just before exiting are already visible under the lock).
-      if self.doorbell.recv().await.is_err() {
-        return lock(&self.queue).ready.pop_front();
+      if self.finished || self.queries.is_empty() {
+        self.finished = true;
+        return None;
       }
-    }
-  }
-
-  /// Number of discoveries dropped because a bound was reached: the
-  /// distinct-instance cap ([`QueryParam::with_max_entries`]), the distinct-host
-  /// cap that bounds an SRV-target flood, or surplus PTR answers evicted by the
-  /// browse query's bounded answer pool before they could be tracked. A non-zero
-  /// value means the result set is a partial view.
-  pub fn dropped(&self) -> u64 {
-    lock(&self.queue).dropped
-  }
-}
-
-impl Endpoint {
-  /// Browse for instances of a DNS-SD service type, resolving each into a
-  /// [`ServiceEntry`]. See [`Lookup`] and [`QueryParam`].
-  pub async fn browse(&self, param: QueryParam) -> Result<Lookup, StartQueryError> {
-    let resolve_timeout = param.resolve_timeout.unwrap_or(param.timeout);
-    let ptr_spec = QuerySpec::new(param.service, ResourceType::Ptr)
-      .with_timeout(param.timeout)
-      .with_unicast_response(param.unicast_response)
-      // Size the PTR answer pool to the requested instance cap so a max_entries
-      // above the query's default answer cap is actually reachable, and the
-      // Resolver — not the query's answer pool — is what bounds and counts
-      // instances (`Lookup::dropped`). Without this, surplus PTR answers would be
-      // evicted before `on_ptr` could track or count them.
-      .with_max_answers(param.max_entries);
-    // Start the browse query up front so a start failure surfaces synchronously
-    // to the caller rather than vanishing inside the spawned task.
-    let ptr_query = self.start_query(ptr_spec).await?;
-    // Capture the browse query's drop counter before it is moved into the
-    // merged stream, so the driver can fold its evictions into `Lookup::dropped`.
-    let ptr_drops = ptr_query.dropped_handle();
-
-    let mut streams = SelectAll::new();
-    streams.push(tagged_stream(ptr_query, Step::Ptr));
-
-    let queue = Arc::new(Mutex::new(LookupQueue::new()));
-    let (doorbell_tx, doorbell_rx) = async_channel::bounded(1);
-    let (cancel_tx, cancel_rx) = async_channel::bounded(1);
-
-    let driver = LookupDriver {
-      endpoint: self.clone(),
-      streams,
-      resolver: Resolver::new(param.max_entries),
-      ptr_drops,
-      queue: Arc::clone(&queue),
-      doorbell: doorbell_tx,
-      cancel: cancel_rx,
-      resolve_timeout,
-      unicast: param.unicast_response,
-    };
-    self.spawn_lookup(driver.run())?;
-
-    Ok(Lookup {
-      queue,
-      doorbell: doorbell_rx,
-      _cancel: cancel_tx,
-    })
-  }
-
-  /// Convenience for [`Self::browse`] with default parameters and the given
-  /// browse timeout.
-  pub async fn lookup(&self, service: Name, timeout: Duration) -> Result<Lookup, StartQueryError> {
-    self
-      .browse(QueryParam::new(service).with_timeout(timeout))
-      .await
-  }
-
-  /// Resolve a host name to its addresses via mDNS A / AAAA queries (RFC 6762),
-  /// without the DNS-SD browse/resolve chain.
-  ///
-  /// Issues both queries and collects every advertised address for the
-  /// `timeout` window (the answer window for multicast responses), returning
-  /// them IPv4 first then IPv6, deduplicated and capped per family. The result
-  /// is empty if nothing answers. Unlike [`Self::resolve_instance`] this does
-  /// not require — or interpret — DNS-SD records; it is the multicast analogue
-  /// of resolving a hostname.
-  pub async fn resolve_host(
-    &self,
-    host: Name,
-    timeout: Duration,
-  ) -> Result<Vec<IpAddr>, StartQueryError> {
-    let host_key = fold(&host);
-    let a = self
-      .start_query(QuerySpec::new(host.clone(), ResourceType::A).with_timeout(timeout))
-      .await?;
-    let aaaa = self
-      .start_query(QuerySpec::new(host, ResourceType::Aaaa).with_timeout(timeout))
-      .await?;
-    let mut streams = SelectAll::new();
-    streams.push(tagged_stream(a, Step::A(host_key.clone())));
-    streams.push(tagged_stream(aaaa, Step::Aaaa(host_key)));
-
-    // Drive both queries to their terminal (the timeout), gathering addresses.
-    // The consumer here is this future itself, so the streams drain promptly.
-    let mut ipv4: Vec<Ipv4Addr> = Vec::new();
-    let mut ipv6: Vec<Ipv6Addr> = Vec::new();
-    while let Some(tagged) = streams.next().await {
-      let ans = match tagged.event {
-        QueryEvent::Answer(a) => a,
-        QueryEvent::Terminal(_) => continue,
+      // Race every live sub-query so a buffered answer on any of them is
+      // processed without parking on the rest.  Awaiting `queries[0].next()`
+      // sequentially would starve queries 1..N (the plan's known bug).
+      let (result, idx) = {
+        let futs: Vec<_> = self
+          .queries
+          .iter()
+          .map(|(q, _)| Box::pin(q.next()))
+          .collect();
+        let (result, idx, _remaining) = select_all(futs).await;
+        // `_remaining` drops here, releasing the immutable borrow on
+        // `self.queries`, so the swap_remove below is sound.
+        (result, idx)
       };
-      match ans.rtype() {
-        ResourceType::A => {
-          if let Ok(r) = ARecord::try_from_rdata(ans.rdata_slice()) {
-            push_capped(&mut ipv4, r.addr());
+      match result {
+        Some(QueryEvent::Answer(answer)) => {
+          let step = self.queries[idx].1.clone();
+          let starts = feed(&mut self.resolver, step, QueryEvent::Answer(answer));
+          self.launch_starts(starts).await;
+        }
+        Some(QueryEvent::Terminal(_)) | None => {
+          self.queries.swap_remove(idx);
+          if self.queries.is_empty() {
+            self.finished = true;
           }
         }
-        ResourceType::Aaaa => {
-          if let Ok(r) = AaaaRecord::try_from_rdata(ans.rdata_slice()) {
-            push_capped(&mut ipv6, r.addr());
-          }
-        }
-        _ => {}
       }
     }
-    Ok(
-      ipv4
-        .into_iter()
-        .map(IpAddr::V4)
-        .chain(ipv6.into_iter().map(IpAddr::V6))
-        .collect(),
-    )
   }
 
-  /// Resolve a *known* DNS-SD service instance directly into a [`ServiceEntry`],
-  /// skipping the PTR browse step (e.g.
-  /// `Name::try_from_str("Office._ipp._tcp.local.")`).
-  ///
-  /// Issues SRV + TXT for the instance and A / AAAA for the SRV target host, and
-  /// returns the first complete resolution — host + port, TXT, and at least one
-  /// address — or `None` if it does not complete within `timeout`. Use
-  /// [`Self::browse`] instead when the instance names are not known in advance.
-  pub async fn resolve_instance(
-    &self,
-    instance: Name,
-    timeout: Duration,
-  ) -> Result<Option<ServiceEntry>, StartQueryError> {
-    // One deadline shared across stages: follow-up A/AAAA queries get the
-    // REMAINING budget, not a fresh full `timeout`, so the whole call stays
-    // bounded by `timeout` as documented (an SRV arriving late can't grant the
-    // address queries a second full window).
-    // `checked_add` so a pathological `timeout` (e.g. `Duration::MAX`) cannot
-    // panic the way `Instant + Duration` would. An overflow means "no effective
-    // deadline", so each stage just receives the full (huge) `timeout`, which
-    // `QuerySpec` clamps with its own checked arithmetic.
-    let deadline = Instant::now().checked_add(timeout);
-    let remaining = || deadline.map_or(timeout, |d| d.saturating_duration_since(Instant::now()));
-    let mut resolver = Resolver::new(1);
-    let mut streams = SelectAll::new();
-    // Seed the resolver with the instance and issue its SRV + TXT (no PTR).
-    for start in resolver.on_ptr(instance) {
-      streams.push(self.launch_resolve(start, remaining()).await?);
-    }
-    // Drive inline until the instance completes or every sub-query times out.
-    while let Some(tagged) = streams.next().await {
-      for start in feed(&mut resolver, tagged) {
-        streams.push(self.launch_resolve(start, remaining()).await?);
-      }
-      if let Some(entry) = resolver.take_ready() {
-        return Ok(Some(entry));
+  async fn launch_starts(&mut self, starts: Vec<Start>) {
+    for start in starts {
+      let qtype = start.qtype();
+      let step = start.step;
+      let spec = QuerySpec::new(start.name, qtype)
+        .with_timeout(self.resolve_timeout)
+        .with_unicast_response(self.unicast);
+      // A `StartQueryError::StorageFull` here just means we can't make
+      // forward progress on this sub-step; the other live queries continue,
+      // and the resolver still terminates when they drain.
+      if let Ok(q) = self.endpoint.start_query(spec).await {
+        self.queries.push((q, step));
       }
     }
-    Ok(resolver.take_ready())
-  }
-
-  /// Start a resolve sub-query and wrap it as a tagged stream. Used by the
-  /// one-shot resolve conveniences, which drive the merged streams inline rather
-  /// than via a spawned [`LookupDriver`].
-  async fn launch_resolve(
-    &self,
-    start: Start,
-    timeout: Duration,
-  ) -> Result<futures::stream::BoxStream<'static, Tagged>, StartQueryError> {
-    let qtype = start.qtype();
-    let query = self
-      .start_query(QuerySpec::new(start.name, qtype).with_timeout(timeout))
-      .await?;
-    Ok(tagged_stream(query, start.step))
   }
 }
 
-/// Decode one tagged answer, fold it into `resolver`, and return any follow-up
-/// queries it requests. Shared by the streaming [`LookupDriver`] and the
+/// Decode one tagged answer, fold it into `resolver`, and return any
+/// follow-up queries it requests.  Shared by [`Lookup::next`] and the
 /// one-shot [`Endpoint::resolve_instance`] convenience.
-fn feed(resolver: &mut Resolver, tagged: Tagged) -> Vec<Start> {
-  let answer = match tagged.event {
+pub(crate) fn feed(resolver: &mut Resolver, step: Step, event: QueryEvent) -> Vec<Start> {
+  let answer = match event {
     QueryEvent::Answer(a) => a,
     QueryEvent::Terminal(_) => return Vec::new(),
   };
-  match tagged.step {
+  match step {
     Step::Ptr => {
       if answer.rtype() != ResourceType::Ptr {
         return Vec::new();
@@ -863,16 +622,16 @@ fn feed(resolver: &mut Resolver, tagged: Tagged) -> Vec<Start> {
       Vec::new()
     }
     Step::A(host_key) => {
-      if let Ok(r) = ARecord::try_from_rdata(answer.rdata_slice()) {
-        if answer.rtype() == ResourceType::A {
+      if answer.rtype() == ResourceType::A {
+        if let Ok(r) = ARecord::try_from_rdata(answer.rdata_slice()) {
           resolver.on_addr(&host_key, IpAddr::V4(r.addr()));
         }
       }
       Vec::new()
     }
     Step::Aaaa(host_key) => {
-      if let Ok(r) = AaaaRecord::try_from_rdata(answer.rdata_slice()) {
-        if answer.rtype() == ResourceType::Aaaa {
+      if answer.rtype() == ResourceType::Aaaa {
+        if let Ok(r) = AaaaRecord::try_from_rdata(answer.rdata_slice()) {
           resolver.on_addr(&host_key, IpAddr::V6(r.addr()));
         }
       }
@@ -881,88 +640,28 @@ fn feed(resolver: &mut Resolver, tagged: Tagged) -> Vec<Start> {
   }
 }
 
-/// Wrap a [`Query`] as a `'static` stream of [`Tagged`] answers for the given
-/// resolve step. The stream ends when the query reaches its terminal.
-fn tagged_stream(query: Query, step: Step) -> futures::stream::BoxStream<'static, Tagged> {
-  futures::stream::unfold((query, step), |(mut query, step)| async move {
-    let event = query.next().await?;
-    let tagged = Tagged {
-      step: step.clone(),
-      event,
-    };
-    Some((tagged, (query, step)))
-  })
-  .boxed()
-}
-
-/// Push `item` into `v` if it is new and `v` is under [`MAX_ADDRS_PER_HOST`].
-/// Returns `true` if it was added (so the caller can decide to (re)emit).
-fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
-  if v.len() >= MAX_ADDRS_PER_HOST || v.contains(&item) {
-    return false;
-  }
-  v.push(item);
-  true
-}
-
-/// Case-fold a name to its lookup key (DNS names are case-insensitive,
-/// RFC 6762 §16).
-fn fold(name: &Name) -> String {
-  name.as_str().to_ascii_lowercase()
-}
-
-/// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
-/// stored in a [`mdns_proto::CollectedAnswer`]) into an owned [`Name`].
-///
-/// Returns `None` for any name the [`Name`] type cannot represent faithfully:
-/// a label containing a `.` (always a separator) or a non-ASCII byte (mangled
-/// by `Name`). Such instances are skipped rather than silently corrupted.
-fn name_from_ref(nr: &NameRef<'_>) -> Option<Name> {
-  let mut s = String::new();
-  for label in nr.labels() {
-    let label = label.ok()?;
-    if label.is_empty() {
-      break; // root terminator
-    }
-    if label.iter().any(|&b| b >= 0x80 || b == b'.') {
-      return None; // not representable by `Name` without corruption
-    }
-    // Verified ASCII above, so this is always valid UTF-8.
-    s.push_str(core::str::from_utf8(label).ok()?);
-    s.push('.');
-  }
-  if s.is_empty() {
-    return None;
-  }
-  Name::try_from_str(&s).ok()
-}
-
-/// Parse a PTR rdata slice (a decompressed wire-form name) into a [`Name`].
-fn parse_name(rdata: &[u8]) -> Option<Name> {
-  let ptr = PtrRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
-  name_from_ref(ptr.target())
-}
-
-/// Parse an SRV rdata slice into `(target host, port)`.
-fn parse_srv(rdata: &[u8]) -> Option<(Name, u16)> {
-  let srv = SrvRecord::try_from_message(rdata, 0, rdata.len()).ok()?;
-  let host = name_from_ref(srv.target())?;
-  Some((host, srv.port()))
-}
-
-/// Parse a TXT rdata slice into its segments (dropping a malformed tail).
-fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
-  TxtRecord::from_rdata(rdata)
-    .segments()
-    .map_while(Result::ok)
-    .map(<[u8]>::to_vec)
-    .collect()
-}
-
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
+  use std::collections::HashSet;
+
   use super::*;
+
+  #[test]
+  fn push_capped_dedups_and_bounds() {
+    let mut v: Vec<u32> = Vec::new();
+    for i in 0..(MAX_ADDRS_PER_HOST as u32 + 8) {
+      push_capped(&mut v, i);
+    }
+    assert_eq!(v.len(), MAX_ADDRS_PER_HOST);
+    let added = push_capped(&mut v, 0); // duplicate
+    assert!(!added);
+  }
+
+  #[test]
+  fn fold_lowercases_ascii() {
+    let n = mdns_proto::Name::try_from_str("Foo.Local.").unwrap();
+    assert_eq!(fold(&n), "foo.local.");
+  }
 
   /// Encode a single label sequence as a decompressed wire-form name.
   fn wire_name(labels: &[&[u8]]) -> Vec<u8> {

--- a/mdns-compio/src/driver.rs
+++ b/mdns-compio/src/driver.rs
@@ -1,0 +1,2120 @@
+//! Driver state, the spawned `run()` loop, and the `LocalNotify` primitive.
+
+// `LocalNotify` is consumed by the driver `run()` loop wired in by T7+; silence
+// `dead_code` until those callers land in the same crate.
+#![allow(dead_code)]
+
+use std::rc::Rc;
+
+use event_listener::Event;
+
+/// Non-atomic notify for waking the driver from handle-side mutations.
+/// Single-thread (`!Send`) by design — built on `event-listener`'s `Event`
+/// primitive but never crosses threads.
+#[derive(Clone)]
+pub(crate) struct LocalNotify {
+  inner: Rc<Event>,
+}
+
+impl LocalNotify {
+  pub(crate) fn new() -> Self {
+    Self {
+      inner: Rc::new(Event::new()),
+    }
+  }
+
+  pub(crate) fn notify(&self) {
+    self.inner.notify(usize::MAX);
+  }
+
+  pub(crate) async fn listen(&self) {
+    self.inner.listen().await;
+  }
+}
+
+use std::{
+  collections::{HashMap, VecDeque},
+  time::{Duration, Instant as StdInstant, SystemTime},
+};
+
+use mdns_proto::{
+  CacheEntry, CollectedAnswer, Endpoint as ProtoEp, EndpointConfig, EndpointEventEntry,
+  QueryHandle, QueryUpdate, ServiceHandle, ServiceRoute, ServiceUpdate, query::Query as ProtoQuery,
+  service::Service as ProtoSvc, transmit::Transmit,
+};
+
+/// RFC 6762 §10.1: a goodbye is multicast a few times for loss resilience.
+/// Matches `mdns-reactor::driver::GOODBYE_SENDS`.
+pub(crate) const GOODBYE_SENDS: u8 = 3;
+
+/// Spacing between successive goodbye resends. Matches
+/// `mdns-reactor::driver::GOODBYE_INTERVAL`.
+pub(crate) const GOODBYE_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Per-iteration cap on the transmit pump.  Mirrors
+/// `mdns-reactor::driver::MAX_SEND_CREDITS_PER_DRAIN` (64) so a misbehaving
+/// proto-state machine — or a transmit yielded for an unbound address family
+/// where `note_*_transmit_result(delivered=false)` does not advance state —
+/// cannot spin the driver in a tight unbounded loop.
+pub(crate) const MAX_TRANSMIT_CREDITS_PER_PASS: usize = 64;
+
+/// IPv4 mDNS multicast destination (224.0.0.251:5353). Used by the goodbye
+/// pump (which doesn't go through `poll_one_transmit`).
+pub(crate) const MDNS_V4_DST: core::net::SocketAddr = core::net::SocketAddr::V4(
+  core::net::SocketAddrV4::new(core::net::Ipv4Addr::new(224, 0, 0, 251), 5353),
+);
+
+/// IPv6 mDNS multicast destination ([ff02::fb]:5353). Used by the goodbye
+/// pump.
+pub(crate) const MDNS_V6_DST: core::net::SocketAddr =
+  core::net::SocketAddr::V6(core::net::SocketAddrV6::new(
+    core::net::Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x00fb),
+    5353,
+    0,
+    0,
+  ));
+
+/// Whether `dst` is an mDNS multicast destination (multicast IP on port
+/// 5353).  `mdns-proto`'s `multicast_dst()` ALWAYS returns the IPv4 group
+/// `224.0.0.251:5353` — even for the IPv6 service group — so the transmit
+/// pump cannot route multicast by the destination's address family. Instead
+/// it detects an mDNS multicast destination here and fans the SAME payload
+/// out to BOTH bound families' multicast groups (RFC 6762 §6: a dual-stack
+/// host answers on each). Mirrors the reactor's `send_via` predicate.
+pub(crate) fn is_mdns_multicast_dst(dst: core::net::SocketAddr) -> bool {
+  use mdns_udp::constants::MDNS_PORT;
+  matches!(dst, core::net::SocketAddr::V4(a) if a.ip().is_multicast() && a.port() == MDNS_PORT)
+    || matches!(dst, core::net::SocketAddr::V6(a) if a.ip().is_multicast() && a.port() == MDNS_PORT)
+}
+
+/// Concrete `mdns-proto::Endpoint` instantiation used by the compio driver.
+/// All pool slots are `slab::Slab`-backed so the std-side state lives in heap-
+/// growable storage rather than heapless fixed buffers.
+pub(crate) type ProtoEndpoint = ProtoEp<
+  StdInstant,
+  rand::rngs::StdRng,
+  slab::Slab<CacheEntry<StdInstant>>,
+  slab::Slab<ServiceRoute>,
+  slab::Slab<ProtoQuery<StdInstant, slab::Slab<CollectedAnswer>, slab::Slab<QueryUpdate>>>,
+  slab::Slab<EndpointEventEntry>,
+  slab::Slab<CollectedAnswer>,
+  slab::Slab<QueryUpdate>,
+>;
+
+/// Concrete `mdns-proto::Service` instantiation used by the compio driver. The
+/// state machine is owned per-`ServiceCtx`; the endpoint only tracks routing
+/// metadata via `ServiceRoute`.
+pub(crate) type ProtoService =
+  ProtoSvc<StdInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>>;
+
+/// Origin tag for a pumped transmit. Carries the source handle so the driver
+/// can route the post-send `note_transmit_result` (and similar) back to the
+/// right per-handle context.
+#[derive(Clone, Copy)]
+pub(crate) enum TransmitOrigin {
+  Service(ServiceHandle),
+  Query(QueryHandle),
+}
+
+/// Whether `upd` is a known lifecycle kind that the coalescer collapses to its
+/// latest occurrence (vs an unknown future `#[non_exhaustive]` variant, which
+/// the bounded backstop in [`push_service_update_coalesced`] handles instead).
+///
+/// `ServiceUpdate` is `#[non_exhaustive]`, so a variant added upstream falls
+/// through to `false` and is bounded by [`MAX_PENDING_SERVICE_UPDATES`] rather
+/// than silently coalescing under semantics we can't know yet.
+fn is_markable(upd: &ServiceUpdate) -> bool {
+  matches!(
+    upd,
+    ServiceUpdate::Established
+      | ServiceUpdate::Renamed(_)
+      | ServiceUpdate::Conflict
+      | ServiceUpdate::HostConflict
+  )
+}
+
+/// Hard cap on a service's pending-update deque. Known lifecycle kinds coalesce
+/// to ≤4 entries; this only bounds hypothetical future `#[non_exhaustive]`
+/// `ServiceUpdate` variants that [`is_markable`] doesn't recognise.
+const MAX_PENDING_SERVICE_UPDATES: usize = 16;
+
+/// Maximum consecutive `Service::poll_transmit` errors before the driver gives
+/// up on a registered service, surfaces [`ServiceUpdate::Conflict`] to the
+/// caller, and marks the service permanently inert (`ServiceCtx::errored`).
+/// Mirrors `mdns-reactor::driver::MAX_CONSECUTIVE_ENCODE_ERRORS`.
+///
+/// The threshold is small because `mdns-proto` PRESERVES (does not pop) the
+/// pending transmit on encode failure — it re-offers the identical oversized
+/// datagram on the next `poll_transmit` — so three failures across consecutive
+/// pump passes mean the payload simply cannot be encoded with the configured
+/// `max_payload` (e.g. a `ServiceRecords` set whose probe/announce exceeds the
+/// scratch buffer). Without escalation that oversized transmit stays
+/// head-of-line forever: the service never advances past probing, never reaches
+/// `Established`, never emits any `ServiceUpdate`, and the handle waits
+/// indefinitely.
+pub(crate) const MAX_CONSECUTIVE_ENCODE_ERRORS: u8 = 3;
+
+/// Append `upd` to a service's update deque, coalescing so memory stays
+/// bounded under churn while preserving the freshest lifecycle signal:
+///
+/// * markable kinds (`Established` / `Renamed` / `Conflict` / `HostConflict`)
+///   keep only the LATEST update of their kind — drop any prior pending update
+///   of the SAME kind (compared by enum discriminant, so a new `Renamed(b)`
+///   supersedes a pending `Renamed(a)` and a fresh `Established` supersedes a
+///   stale earlier one), then append the new event at the back.
+/// * any future non-markable variant — append but stay bounded by dropping the
+///   oldest entry past [`MAX_PENDING_SERVICE_UPDATES`] (defensive backstop,
+///   unreachable with today's enum).
+///
+/// Dedup is by KIND, not by position, so a genuinely new event of a kind seen
+/// earlier survives: the second `Established` in
+/// `Established -> Renamed -> Established` (the §9 conflict-rename re-probe path,
+/// `mdns_proto::service`) drops the STALE first `Established`, not the new one —
+/// a by-kind-keep-first policy would wrongly discard the post-rename
+/// confirmation that the renamed service is now advertised. The deque therefore
+/// holds at most one entry per kind (≤ 4) regardless of how much an on-link peer
+/// churns conflict-renames. Mirrors the latest-of-kind contract of
+/// `mdns-reactor::driver`'s service-update coalescing.
+fn push_service_update_coalesced(updates: &mut VecDeque<ServiceUpdate>, upd: ServiceUpdate) {
+  if is_markable(&upd) {
+    // Known lifecycle event: keep only the latest of its kind.
+    let kind = core::mem::discriminant(&upd);
+    updates.retain(|u| core::mem::discriminant(u) != kind);
+    updates.push_back(upd);
+  } else {
+    // Future non-markable variant: append, bounded by a hard cap (drop oldest
+    // to preserve recency) — defensive backstop, unreachable with today's enum.
+    if updates.len() >= MAX_PENDING_SERVICE_UPDATES {
+      updates.pop_front();
+    }
+    updates.push_back(upd);
+  }
+}
+
+/// Driver-side per-service context: the owned proto state machine, a bounded
+/// and coalescing update queue, and a cancellation flag. Methods land in T8
+/// and the driver loop consumes them in T9.
+///
+/// `updates` is bounded by coalescing in [`push_service_update_coalesced`]:
+/// every known lifecycle kind (`Established` / `Renamed` / `Conflict` /
+/// `HostConflict`) keeps only the LATEST entry of its kind (a new one drops the
+/// prior of the same kind and re-appends at the back) — so the deque holds at
+/// most one of each kind (≤ 4 entries) regardless of churn, with
+/// [`MAX_PENDING_SERVICE_UPDATES`] as a hard-cap backstop for any future
+/// `#[non_exhaustive]` variant that [`is_markable`] doesn't recognise. Keeping
+/// the LATEST (not the first) preserves the post-rename `Established` across an
+/// `Established -> Renamed -> Established` sequence. This stops a hostile on-link
+/// peer from growing the deque without bound by spamming conflict-bearing
+/// packets while the app isn't draining `Service::next`.
+pub(crate) struct ServiceCtx {
+  pub(crate) proto: ProtoService,
+  pub(crate) updates: VecDeque<ServiceUpdate>,
+  pub(crate) cancelled: bool,
+  /// Count of consecutive `proto.poll_transmit` errors for this service. Reset
+  /// to 0 on any `Ok` (a successful encode or an empty queue); incremented on
+  /// each `Err`. Once it reaches [`MAX_CONSECUTIVE_ENCODE_ERRORS`] the service
+  /// is escalated to [`ServiceUpdate::Conflict`] and marked [`Self::errored`].
+  pub(crate) encode_failures: u8,
+  /// Terminal "this service is structurally dead" flag. Set once a persistent
+  /// encode failure escalated to `Conflict`. Unlike the reactor — which removes
+  /// the `ServiceCtx` immediately after emitting `Conflict` because its updates
+  /// live in an independently-buffered channel — the compio `ServiceUpdate`s
+  /// live INSIDE `ServiceCtx.updates`, which `Service::next` drains directly.
+  /// Removing the ctx here would destroy the `Conflict` before the handle could
+  /// read it (the exact silent-failure this fix closes), so instead the ctx is
+  /// kept but flagged `errored`: every proto-polling pump skips it (so a dead
+  /// proto can't be re-polled into a busy-spin) while the already-queued
+  /// `Conflict` stays readable. The slot is freed normally when the `Service`
+  /// handle is dropped (the `flag_service_unregistered` → sweep path).
+  pub(crate) errored: bool,
+  /// One-shot "wake a parked `Service::next` for the escalation `Conflict`"
+  /// flag. The escalation pushes `Conflict` into `updates` from inside the
+  /// transmit pump, which is NOT the wake-bearing path: [`Self::errored`] makes
+  /// every later pump skip this ctx, so `push_service_updates` no longer reports
+  /// it as needing a wake. Set this once at escalation;
+  /// [`State::push_service_updates`] consumes it to fire exactly one `notify`,
+  /// so a handle parked on an otherwise-idle endpoint (no other service / query
+  /// / goodbye deadline) still gets woken to read the `Conflict`. Cleared after
+  /// that single wake so an undrained `Conflict` can't drive a notify busy-spin.
+  pub(crate) conflict_wake_pending: bool,
+}
+
+/// Driver-side per-query context: last-delivered sequence number and a
+/// cancellation flag.
+pub(crate) struct QueryCtx {
+  pub(crate) last_seq: u64,
+  pub(crate) cancelled: bool,
+  /// Terminal "this query is structurally dead" flag, set when its question
+  /// persistently fails to encode into `max_payload` (the proto preserves the
+  /// pending transmit on `Err`, so it would otherwise stay head-of-line
+  /// forever). Unlike a service, a query has no `Conflict`-style update to
+  /// surface and `QueryUpdate` is `#[non_exhaustive]` (so the driver cannot mint
+  /// a terminal variant), so `Query::next` reports end-of-stream (`None`) —
+  /// the same signal it already uses for the cancelled-drop path — rather than
+  /// parking forever. A query with `QuerySpec` timeout `None` has no
+  /// `timeout_deadline` and an un-encodable first send never schedules a
+  /// `next_deadline`, so without this flag `poll_deadline` would have nothing to
+  /// wake on and `Query::next` would hang indefinitely (codex R7).
+  pub(crate) errored: bool,
+  /// One-shot: armed when `errored` is first set, consumed by the run loop to
+  /// fire exactly one `notify` so a `Query::next` parked on an otherwise-idle
+  /// endpoint wakes to observe the end-of-stream. Cleared after firing so an
+  /// undrained terminal can't drive a notify busy-spin (mirrors
+  /// `ServiceCtx::conflict_wake_pending`).
+  pub(crate) terminal_wake_pending: bool,
+}
+
+/// A pending RFC 6762 §10.1 goodbye broadcast queued by service withdrawal.
+/// The encoded datagram is self-contained; the proto `Service` is removed
+/// immediately so withdrawal proceeds even after the state machine is gone.
+pub(crate) struct PendingGoodbye {
+  /// Fully encoded TTL=0 datagram (records of the withdrawn service).
+  pub(crate) data: Vec<u8>,
+  /// Remaining sends; the entry is dropped once this reaches zero.
+  pub(crate) remaining: u8,
+  /// Earliest wall-clock instant at which the next send may go out.
+  pub(crate) next_at: StdInstant,
+}
+
+/// All state owned by the compio driver task. Held behind the `RefCell` in
+/// `EndpointInner` (T9) — no `Arc` / `Mutex` / atomics: every borrower is on the
+/// same `!Send` runtime thread.
+pub(crate) struct State {
+  pub(crate) endpoint: ProtoEndpoint,
+  pub(crate) services: HashMap<ServiceHandle, ServiceCtx>,
+  pub(crate) queries: HashMap<QueryHandle, QueryCtx>,
+  /// Self-send tracker — `(content_hash, body_len, send_wall_time)` for every
+  /// datagram we recently transmitted, used by T16's loopback-self detection.
+  pub(crate) recent_sends: crate::selfsend::SelfSends,
+  /// TTL=0 goodbye packets resent a few times before being dropped.
+  pub(crate) goodbyes: Vec<PendingGoodbye>,
+  /// Bound interface index (1-based) used for §11 link-local scoping.
+  pub(crate) bound_interface: u32,
+  /// Cached local subnets used for the §11 source-address fallback when the
+  /// kernel didn't deliver an IPv4 TTL / IPv6 hop-limit cmsg.
+  pub(crate) local_subnets: Vec<(core::net::IpAddr, u8)>,
+  /// Max datagram size; used to size the scratch buffer for the encode/send
+  /// path (T8/T9) and the goodbye-encoding path. Sourced from
+  /// [`crate::ServerOptions::max_payload_size`].
+  pub(crate) max_payload: usize,
+  /// Max inbound-datagram size accepted without truncation. Sourced from
+  /// [`crate::ServerOptions::max_recv_packet_size`] (RFC 6762 §17 requires
+  /// implementations to accept up to 9000 bytes by default).
+  pub(crate) max_recv: usize,
+}
+
+impl State {
+  /// Build a fresh driver state with no services, queries, or goodbye queue
+  /// entries, seeded with an OS-derived [`rand::rngs::StdRng`]. Bound
+  /// interface and local-subnet snapshot stay empty until T9 wires them in
+  /// from the bound sockets / interface discovery.
+  pub(crate) fn new(cfg: EndpointConfig, max_payload: usize, max_recv: usize) -> Self {
+    use rand::SeedableRng;
+    // rand 0.10 removed `from_entropy`; seed StdRng from the OS-seeded
+    // thread RNG (same idiom as `mdns-reactor::driver::DriverState::new`).
+    let rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
+    Self {
+      endpoint: ProtoEndpoint::try_new(cfg, rng),
+      services: HashMap::new(),
+      queries: HashMap::new(),
+      recent_sends: Vec::new(),
+      goodbyes: Vec::new(),
+      bound_interface: 0,
+      local_subnets: Vec::new(),
+      max_payload,
+      max_recv,
+    }
+  }
+
+  /// Register a service spec with the endpoint and create an empty driver-side
+  /// context for it. T11 wires the per-service update channel into [`ServiceCtx`].
+  pub(crate) fn register_service(
+    &mut self,
+    spec: mdns_proto::ServiceSpec,
+    now: StdInstant,
+  ) -> Result<ServiceHandle, mdns_proto::error::RegisterServiceError> {
+    let (handle, svc) = self
+      .endpoint
+      .try_register_service::<slab::Slab<_>, slab::Slab<_>>(spec, now)?;
+    self.services.insert(
+      handle,
+      ServiceCtx {
+        proto: svc,
+        updates: VecDeque::new(),
+        cancelled: false,
+        encode_failures: 0,
+        errored: false,
+        conflict_wake_pending: false,
+      },
+    );
+    Ok(handle)
+  }
+
+  /// Start a query against the endpoint and create an empty driver-side context
+  /// for it. T13 wires per-query mailboxes / `last_seq` updates.
+  pub(crate) fn start_query(
+    &mut self,
+    spec: mdns_proto::QuerySpec,
+    now: StdInstant,
+  ) -> Result<QueryHandle, mdns_proto::error::StartQueryError> {
+    let h = self.endpoint.try_start_query(spec, now)?;
+    self.queries.insert(
+      h,
+      QueryCtx {
+        last_seq: 0,
+        cancelled: false,
+        errored: false,
+        terminal_wake_pending: false,
+      },
+    );
+    Ok(h)
+  }
+
+  /// Flag a query as cancelled.  The driver loop (T9) sweeps cancelled
+  /// queries on the next poll cycle and calls `endpoint.cancel_query`.
+  pub(crate) fn flag_query_cancelled(&mut self, h: QueryHandle) {
+    if let Some(q) = self.queries.get_mut(&h) {
+      q.cancelled = true;
+    }
+  }
+
+  /// Flag a service as withdrawn (called from [`Service::drop`]). The actual
+  /// proto-state removal + RFC 6762 §10.1 goodbye encoding is deferred to the
+  /// driver loop's [`Self::sweep_cancelled_services`], which runs after the
+  /// transmit pump so any in-flight send latches first. The `cancelled` flag is
+  /// meanwhile honoured by [`Self::poll_one_transmit`] and [`Self::fire_timeouts`]
+  /// so a withdrawn service emits no further probes/announces before the sweep.
+  pub(crate) fn flag_service_unregistered(&mut self, h: ServiceHandle) {
+    if let Some(s) = self.services.get_mut(&h) {
+      s.cancelled = true;
+    }
+  }
+
+  /// Remove a service: encode its RFC 6762 §10.1 goodbye (TTL=0) records
+  /// while the proto state is still present, drop the proto state, and
+  /// release the endpoint's route slot.
+  ///
+  /// Mirrors `mdns-reactor::driver::DriverState::remove_service` (per-record
+  /// goodbye ownership, sibling-host address retention, drained
+  /// conflict-rename withdrawal). The encoded datagrams are pushed onto
+  /// `self.goodbyes` — the driver loop's goodbye pump fans each one out to
+  /// the bound multicast sockets [`GOODBYE_SENDS`] times spaced by
+  /// [`GOODBYE_INTERVAL`]. A service that never reached the announced state
+  /// yields `None` from `encode_goodbye`, so nothing is queued.
+  pub(crate) fn remove_service(&mut self, handle: ServiceHandle, now: StdInstant) {
+    let cap = self.max_payload.max(512);
+
+    // Per-address sibling retention: another local service may still own a
+    // subset of THIS service's host addresses. Collect each sibling's
+    // confirmed-emitted (advertised) addresses; the goodbye encoder
+    // withdraws only the addresses this service advertised that no sibling
+    // is still keeping in peer caches.
+    let retained_host_addrs: Vec<core::net::IpAddr> = if let Some(ctx) = self.services.get(&handle)
+    {
+      let host = ctx.proto.records().host().clone();
+      let mut set: Vec<core::net::IpAddr> = Vec::new();
+      for (h, other) in self.services.iter() {
+        if *h != handle && other.proto.records().host() == &host {
+          set.extend(
+            other
+              .proto
+              .advertised_a_addrs()
+              .iter()
+              .map(|a| core::net::IpAddr::V4(*a)),
+          );
+          set.extend(
+            other
+              .proto
+              .advertised_aaaa_addrs()
+              .iter()
+              .map(|a| core::net::IpAddr::V6(*a)),
+          );
+        }
+      }
+      set
+    } else {
+      Vec::new()
+    };
+
+    // Encode withdrawals while proto state is still present. Collect into a
+    // local Vec first so the borrow of `self.services` is released before
+    // pushing into `self.goodbyes`.
+    let mut pending_datagrams: Vec<Vec<u8>> = Vec::new();
+    if let Some(ctx) = self.services.get_mut(&handle) {
+      let mut buf = vec![0u8; cap];
+      if let Ok(Some(len)) = ctx.proto.encode_goodbye(&mut buf, &retained_host_addrs) {
+        buf.truncate(len);
+        pending_datagrams.push(buf);
+      }
+      // A conflict-rename may have queued an unsent withdrawal of the OLD
+      // instance records inside the proto. Removal drops that proto state,
+      // so drain those bytes here too — otherwise the old name lingers in
+      // peer caches until TTL expiry.
+      let mut rbuf = vec![0u8; cap];
+      if let Ok(Some(rlen)) = ctx.proto.take_pending_rename_goodbye(&mut rbuf) {
+        rbuf.truncate(rlen);
+        pending_datagrams.push(rbuf);
+      }
+    }
+    for data in pending_datagrams {
+      self.goodbyes.push(PendingGoodbye {
+        data,
+        remaining: GOODBYE_SENDS,
+        next_at: now,
+      });
+    }
+
+    self.services.remove(&handle);
+    let _ = self.endpoint.unregister_service(handle);
+  }
+
+  /// Drive endpoint + per-query timer-based work.  Per-service lifecycle
+  /// timers fire via `ctx.proto.handle_timeout` from the driver loop (T9 / T11);
+  /// at T8 only the endpoint cache sweep and query timeouts are exposed.
+  pub(crate) fn fire_timeouts(&mut self, now: StdInstant) {
+    let _ = self.endpoint.handle_timeout(now);
+    let handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
+    for h in handles {
+      // Don't tick a structurally-dead query's proto (see `QueryCtx::errored`).
+      if self.queries.get(&h).is_some_and(|c| c.errored) {
+        continue;
+      }
+      let _ = self.endpoint.handle_query_timeout(h, now);
+    }
+    let svc_handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
+    for h in svc_handles {
+      if let Some(ctx) = self.services.get_mut(&h) {
+        // Don't tick a withdrawn (cancelled) or structurally-dead (errored)
+        // service's proto — a dead proto must not be driven (see
+        // `ServiceCtx::errored`).
+        if !ctx.cancelled && !ctx.errored {
+          let _ = ctx.proto.handle_timeout(now);
+        }
+      }
+    }
+  }
+
+  /// Remove every service flagged `cancelled` by [`Service::drop`], encoding
+  /// each one's RFC 6762 §10.1 goodbye via [`Self::remove_service`]. Returns
+  /// `true` if at least one service was swept.
+  ///
+  /// The driver calls this AFTER the transmit pump, never from `Service::drop`
+  /// directly. The ordering is load-bearing: a service whose announce/response
+  /// was in flight (mid-`send_to().await`) when its handle dropped only latches
+  /// those records as advertised once the send completes and the pump calls
+  /// [`Self::note_service_transmit_result`]. Sweeping after the pump guarantees
+  /// `remove_service` sees the latched records and includes them in the
+  /// goodbye. Encoding the goodbye synchronously in `Drop` — before the await
+  /// completed — would miss the just-sent record and leak a positive-TTL entry
+  /// into peer caches with no TTL=0 withdrawal (the §10.1 violation this fixes).
+  pub(crate) fn sweep_cancelled_services(&mut self, now: StdInstant) -> bool {
+    let cancelled: Vec<ServiceHandle> = self
+      .services
+      .iter()
+      .filter(|(_, ctx)| ctx.cancelled)
+      .map(|(h, _)| *h)
+      .collect();
+    let swept = !cancelled.is_empty();
+    for h in cancelled {
+      self.remove_service(h, now);
+    }
+    swept
+  }
+
+  /// Final withdrawal flush for driver shutdown. Sweeps any still-cancelled
+  /// service (encoding its RFC 6762 §10.1 goodbye) and then DRAINS the entire
+  /// goodbye queue into a flat list of datagrams — each pending entry expanded
+  /// to its `remaining` burst copies — leaving `self.goodbyes` empty.
+  ///
+  /// The driver calls this on the last-handle-drop path INSTEAD of the normal
+  /// timer-spaced goodbye pump. Once every external handle is gone the driver
+  /// is about to exit and can't stay alive for the inter-burst
+  /// [`GOODBYE_INTERVAL`] spacing, so it flushes all remaining bursts
+  /// back-to-back to get the TTL=0 records on the wire before teardown. Without
+  /// this, a service whose handle was the last `Rc` would be flagged cancelled
+  /// but never swept — the loop's bottom-of-iteration shutdown check would exit
+  /// before the next top-of-loop sweep ran — leaking a positive-TTL record into
+  /// peer caches with no withdrawal (the §10.1 violation this closes).
+  ///
+  /// Returns owned datagrams so the caller sends them under no `RefCell` borrow.
+  pub(crate) fn take_shutdown_goodbyes(&mut self, now: StdInstant) -> Vec<Vec<u8>> {
+    self.sweep_cancelled_services(now);
+    let mut out = Vec::new();
+    for g in self.goodbyes.drain(..) {
+      for _ in 0..g.remaining {
+        out.push(g.data.clone());
+      }
+    }
+    out
+  }
+
+  /// Drain pending `ServiceUpdate`s out of each per-service proto state machine
+  /// into the driver-side `ctx.updates` deque so `Service::next` can pop them.
+  /// Returns `true` if at least one update was pushed (so the caller knows to
+  /// bump `notify` and wake any parked listener).
+  pub(crate) fn push_service_updates(&mut self) -> bool {
+    let mut pushed_any = false;
+    // Iterate by handle (not `values_mut`) so each iteration can take DISJOINT
+    // `&mut` access to `self.endpoint` (for `handle_service_renamed`) and
+    // `self.services.get_mut(&h)` — a single `values_mut()` borrow would lock
+    // `self.endpoint` out.
+    let handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
+    for h in handles {
+      // A structurally-dead proto (see `ServiceCtx::errored`) is never polled —
+      // it can't produce more updates. Its escalation `Conflict` was already
+      // queued into `ctx.updates` by the transmit pump and is drained directly
+      // by `Service::next`, not through this pump. But the pump IS the
+      // wake-bearing path, so consume the one-shot `conflict_wake_pending` here
+      // to fire exactly one `notify` for that queued `Conflict` (so a handle
+      // parked on an otherwise-idle endpoint still wakes), then skip the proto.
+      if self.services.get(&h).is_some_and(|c| c.errored) {
+        if let Some(ctx) = self.services.get_mut(&h) {
+          if ctx.conflict_wake_pending {
+            ctx.conflict_wake_pending = false;
+            pushed_any = true;
+          }
+        }
+        continue;
+      }
+      // Drain this service's proto events one at a time. A `Renamed` requires
+      // routing the endpoint to the new instance name BEFORE the update is
+      // surfaced; everything else is queued directly.
+      // Each `proto.poll()` returns an owned `Option<ServiceUpdate>` and drops
+      // its `&mut` borrow before the body runs, so the body can re-borrow
+      // `self.services` / `self.endpoint` freely.
+      while let Some(upd) = self.services.get_mut(&h).and_then(|c| c.proto.poll()) {
+        // RFC 6762 §9 auto-rename: the proto picked a new instance name after a
+        // probe conflict and has already mutated its own records to it. The
+        // endpoint's route table still points at the OLD name, so datagrams for
+        // the new name (and local rename-collision detection) won't route until
+        // we call `handle_service_renamed`. Do it BEFORE surfacing the update,
+        // mirroring `mdns-reactor::driver`. If the proto rejects the new name
+        // (already owned by another local service), the service has already
+        // rebranded and can't be kept: surface `Conflict`, flag it errored so
+        // every pump skips it, and stop draining it.
+        if let ServiceUpdate::Renamed(ref renamed) = upd {
+          let new_name = renamed.new_name().clone();
+          match self.endpoint.handle_service_renamed(h, new_name) {
+            Ok(()) => {}
+            Err(_e) => {
+              tracing::warn!(
+                handle = ?h,
+                error = ?_e,
+                "auto-rename collided with another local service; emitting Conflict and marking errored"
+              );
+              if let Some(ctx) = self.services.get_mut(&h) {
+                push_service_update_coalesced(&mut ctx.updates, ServiceUpdate::Conflict);
+                ctx.errored = true;
+                ctx.conflict_wake_pending = true;
+              }
+              pushed_any = true;
+              break;
+            }
+          }
+        }
+        if let Some(ctx) = self.services.get_mut(&h) {
+          push_service_update_coalesced(&mut ctx.updates, upd);
+        }
+        // Wake on every drained proto update regardless of whether coalescing
+        // dropped it, so a parked `Service::next` still re-checks state. This
+        // matches the pre-coalescing wake semantics.
+        pushed_any = true;
+      }
+    }
+    pushed_any
+  }
+
+  /// Extract one outgoing datagram into `scratch`. Returns
+  /// `Some((dst, used, origin))` or `None`. Walks services first, then queries.
+  /// The driver loop (T9) repeatedly calls this until `None`, sending each
+  /// datagram via the matching socket. The `origin` carries the service handle
+  /// that produced the datagram so the driver can call `note_transmit_result`
+  /// after the send completes — the §8.1 probe sequence and §8.3 announce phase
+  /// only advance once each pending datagram is acknowledged.
+  pub(crate) fn poll_one_transmit(
+    &mut self,
+    now: StdInstant,
+    scratch: &mut [u8],
+  ) -> Option<(core::net::SocketAddr, usize, TransmitOrigin)> {
+    let svc_handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
+    for h in svc_handles {
+      let Some(ctx) = self.services.get_mut(&h) else {
+        continue;
+      };
+      // Skip a cancelled (withdrawn, awaiting sweep) or errored (structurally
+      // dead, see `ServiceCtx::errored`) service so neither is re-polled into a
+      // busy-spin.
+      if ctx.cancelled || ctx.errored {
+        continue;
+      }
+      // distinguish `Ok(None)` ("nothing pending") from `Err`
+      // ("can't encode the pending transmit"). `mdns-proto` PRESERVES the
+      // pending transmit on encode failure, re-offering the identical oversized
+      // datagram every call, so treating `Err` like `Ok(None)` (the prior
+      // `if let Ok(Some(_))` bug) leaves it head-of-line forever and the service
+      // silently stalls below `Established`. Count consecutive failures and
+      // escalate to `ServiceUpdate::Conflict` once they cross the threshold.
+      match ctx.proto.poll_transmit(now, scratch) {
+        Ok(Some(t)) => {
+          ctx.encode_failures = 0;
+          return Some((t.dst(), t.size(), TransmitOrigin::Service(h)));
+        }
+        Ok(None) => {
+          ctx.encode_failures = 0;
+          // Nothing pending for this service — fall through to the next one.
+        }
+        Err(_e) => {
+          ctx.encode_failures = ctx.encode_failures.saturating_add(1);
+          if ctx.encode_failures >= MAX_CONSECUTIVE_ENCODE_ERRORS {
+            // Persistent encode failure: the records can't fit `max_payload`.
+            // Push `Conflict` into the in-ctx update deque (the handle drains it
+            // directly via `Service::next`), flag the service `errored` so every
+            // proto-polling pump skips it from here on, and arm the one-shot
+            // `conflict_wake_pending` so the next `push_service_updates` fires a
+            // single wake for the queued `Conflict`. Do NOT remove the ctx —
+            // that would destroy the `Conflict` before the handle reads it. The
+            // slot is freed normally when the `Service` handle drops.
+            tracing::warn!(
+              handle = ?h,
+              error = ?_e,
+              scratch_size = scratch.len(),
+              consecutive_failures = ctx.encode_failures,
+              "Service::poll_transmit failed; escalating to Conflict and marking the service errored"
+            );
+            push_service_update_coalesced(&mut ctx.updates, ServiceUpdate::Conflict);
+            ctx.errored = true;
+            ctx.conflict_wake_pending = true;
+          }
+          // Whether or not we escalated, do NOT return the un-encodable
+          // transmit as a phantom send — fall through to the next service.
+        }
+      }
+    }
+    let q_handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
+    for h in q_handles {
+      let Some(ctx) = self.queries.get_mut(&h) else {
+        continue;
+      };
+      // Skip a cancelled (handle dropped) or errored (structurally dead, see
+      // `QueryCtx::errored`) query so neither is re-polled into a busy-spin.
+      if ctx.cancelled || ctx.errored {
+        continue;
+      }
+      match self.endpoint.poll_query_transmit(h, now, scratch) {
+        // A datagram is ready — hand it to the driver to send.
+        Ok(Some(t)) => return Some((t.dst(), t.size(), TransmitOrigin::Query(h))),
+        // Nothing due right now — try the next query.
+        Ok(None) => {}
+        // The question can't be encoded into `scratch` (e.g. `max_payload`
+        // smaller than a DNS header + question). The proto PRESERVES the pending
+        // transmit on `Err`, so it would be re-offered forever and the query
+        // would never make progress. Crucially a `QuerySpec` with the default
+        // `timeout` of `None` has no `timeout_deadline`, and an un-encodable
+        // first send never schedules a `next_deadline`, so `poll_deadline` would
+        // have nothing to wake on and a parked `Query::next` would hang
+        // indefinitely (codex R7). Mark the query errored so every proto-polling
+        // pump skips it and `Query::next` surfaces end-of-stream (`None`) — we
+        // can't mint a `QueryUpdate` terminal (the enum is `#[non_exhaustive]`),
+        // and `None` is the same end signal the cancelled-drop path already uses.
+        Err(_e) => {
+          if let Some(ctx) = self.queries.get_mut(&h) {
+            // Arm the one-shot terminal wake only on the transition into
+            // `errored` (not on every re-poll, which can't happen anyway since
+            // errored queries are skipped above — but guard it for clarity).
+            if !ctx.errored {
+              ctx.errored = true;
+              ctx.terminal_wake_pending = true;
+            }
+          }
+          tracing::warn!(
+            handle = ?h,
+            error = ?_e,
+            scratch_size = scratch.len(),
+            "Query::poll_query_transmit failed to encode; marking the query errored (Query::next will report end-of-stream)"
+          );
+        }
+      }
+    }
+    None
+  }
+
+  /// Confirm a previously polled service transmit. Called by the driver loop
+  /// after `send_to` returns, so the per-service state machine can advance the
+  /// §8.1 probe sequence and §8.3 announce phase (which require the post-send
+  /// `delivered` flag to clear `awaiting_confirm`). For query transmits the
+  /// proto layer holds no equivalent commit token, so this is a no-op there.
+  pub(crate) fn note_service_transmit_result(
+    &mut self,
+    h: ServiceHandle,
+    now: StdInstant,
+    delivered: bool,
+  ) {
+    if let Some(ctx) = self.services.get_mut(&h) {
+      ctx.proto.note_transmit_result(now, delivered);
+    }
+  }
+
+  /// Confirm a previously polled query transmit so the proto layer advances
+  /// its §5.2 backoff and retry budget only on a confirmed-delivered send.
+  /// Mirrors [`Self::note_service_transmit_result`] for the query side; called
+  /// by the driver loop after `send_to` returns.
+  pub(crate) fn note_query_transmit_result(
+    &mut self,
+    h: QueryHandle,
+    now: StdInstant,
+    delivered: bool,
+  ) {
+    self.endpoint.note_query_transmit_result(h, now, delivered);
+  }
+
+  /// Whether any service is flagged cancelled but not yet swept by
+  /// [`Self::sweep_cancelled_services`]. The driver uses this to force an
+  /// immediate (zero-duration) timer instead of parking. `Service::drop` flags
+  /// the service and calls `notify()`, but the shared `LocalNotify` wake is lost
+  /// when it lands while the driver is mid-`send_to` await with no listener
+  /// armed, so the wake alone cannot be relied on to run the withdrawal sweep
+  /// and its §10.1 goodbye — the forced timer is what guarantees it.
+  pub(crate) fn has_pending_withdrawal(&self) -> bool {
+    self.services.values().any(|ctx| ctx.cancelled)
+  }
+
+  /// Consume every armed [`QueryCtx::terminal_wake_pending`], returning `true`
+  /// if at least one fired. The run loop calls this after the pumps: a query
+  /// that just transitioned to `errored` (un-encodable question, see
+  /// [`QueryCtx::errored`]) has no standing deadline, so the driver fires one
+  /// `notify` here to wake a parked `Query::next` to observe end-of-stream. The
+  /// flag is one-shot (cleared on consume) so an undrained terminal can't drive
+  /// a notify busy-spin.
+  pub(crate) fn take_query_terminal_wakes(&mut self) -> bool {
+    let mut woke = false;
+    for ctx in self.queries.values_mut() {
+      if ctx.terminal_wake_pending {
+        ctx.terminal_wake_pending = false;
+        woke = true;
+      }
+    }
+    woke
+  }
+
+  /// Earliest deadline across the endpoint, services, queries, and the
+  /// pending-goodbye resend queue.
+  pub(crate) fn poll_deadline(&self) -> Option<StdInstant> {
+    let mut best = self.endpoint.poll_timeout();
+    for ctx in self.services.values() {
+      // A structurally-dead service (see `ServiceCtx::errored`) must not
+      // contribute a deadline — otherwise its proto could report an immediate
+      // (or no) timeout that pins the driver awake despite never being polled.
+      if ctx.errored {
+        continue;
+      }
+      if let Some(t) = ctx.proto.poll_timeout() {
+        best = Some(best.map_or(t, |b| b.min(t)));
+      }
+    }
+    for (h, ctx) in &self.queries {
+      // A structurally-dead query (see `QueryCtx::errored`) must not contribute
+      // a deadline — it is never polled again, and contributing an immediate/no
+      // deadline would busy-spin (unlike a cancelled service it is not swept, so
+      // it persists until its handle drops). Its end-of-stream terminal is
+      // delivered to `Query::next` via a one-shot wake (`terminal_wake_pending`)
+      // drained in the run loop, not via a standing deadline.
+      if ctx.errored {
+        continue;
+      }
+      if let Some(t) = self.endpoint.poll_query_timeout(*h) {
+        best = Some(best.map_or(t, |b| b.min(t)));
+      }
+    }
+    // Wake to resend any pending TTL=0 goodbye when it comes due so the
+    // §10.1 burst completes even between recv / timer events.
+    for g in &self.goodbyes {
+      best = Some(best.map_or(g.next_at, |b| b.min(g.next_at)));
+    }
+    best
+  }
+
+  /// Apply §11 + self-send + `proto.handle` for one received datagram.
+  ///
+  /// The §11 on-link gate lives in [`crate::onlink`] and the FNV-1a self-send
+  /// tracker (take-once classification with [`crate::selfsend::MatchMode`])
+  /// lives in [`crate::selfsend`].
+  pub(crate) fn handle_datagram(&mut self, meta: &crate::socket::RecvMeta, data: &[u8]) {
+    // §11 on-link gate.  When the kernel delivered a TTL / hop-limit we trust
+    // it (must be 255); otherwise we fall back to a source-address heuristic
+    // anchored by the cached local-subnet snapshot.
+    let on_link = if meta.hop_limit.is_some() {
+      crate::onlink::is_on_link(meta.hop_limit)
+    } else {
+      crate::onlink::src_on_local_link(
+        &self.local_subnets,
+        self.bound_interface,
+        meta.interface_index,
+        meta.peer.ip(),
+      )
+    };
+    if !on_link {
+      return;
+    }
+
+    // §11 source-port gate for responses before consuming a self-send credit.
+    // A response (QR=1) from a non-5353 source can't be a legitimate mDNS
+    // response (legacy queriers may use ephemeral ports for queries, not for
+    // responses).  `endpoint.handle` enforces this again internally, but we
+    // bail early so an off-path datagram never consumes a self-send credit.
+    if data.get(2).is_some_and(|b| b & 0x80 != 0)
+      && meta.peer.port() != mdns_udp::constants::MDNS_PORT
+    {
+      return;
+    }
+
+    // Self-send classification (FNV-1a content-hash, take-once).
+    let caller_is_self = match meta.kernel_rx_time {
+      Some(rx) => crate::selfsend::take_self_send(
+        &mut self.recent_sends,
+        data,
+        rx,
+        crate::selfsend::MatchMode::Ordered,
+      ),
+      None => crate::selfsend::take_self_send(
+        &mut self.recent_sends,
+        data,
+        SystemTime::now(),
+        crate::selfsend::MatchMode::Degraded,
+      ),
+    };
+
+    // Use a process-monotonic `now` for proto scheduling; the SystemTime
+    // reference above is what classified the self-send credit.
+    let now = StdInstant::now();
+
+    // Split-borrow: endpoint and services are disjoint fields, but
+    // `endpoint.handle` borrows `self.endpoint` mutably while the route-event
+    // iterator is alive, so the per-service `handle_event` calls can only read
+    // from `services` through a second mutable borrow — keep them disjoint.
+    let Self {
+      endpoint, services, ..
+    } = self;
+
+    let route_events = match endpoint.handle(
+      now,
+      meta.peer,
+      meta.local_ip,
+      meta.interface_index,
+      data,
+      caller_is_self,
+    ) {
+      Ok(it) => it,
+      Err(_) => return,
+    };
+
+    for ev in route_events {
+      match ev {
+        Ok(mdns_proto::event::RouteEvent::ToService(ts)) => {
+          if let Some(ctx) = services.get_mut(&ts.handle()) {
+            ctx.proto.handle_event(ts.into_event(), now);
+          }
+        }
+        // `ToQuery` answers are applied inside `endpoint.handle`;
+        // `CacheUpdated` is a hint for future cache subscribers. Any
+        // additional `RouteEvent` variants are ignored until wired by
+        // T11/T13.
+        Ok(_) => {}
+        Err(_) => break,
+      }
+    }
+  }
+}
+
+use core::cell::RefCell;
+
+use crate::socket::{RecvMeta, Socket};
+
+/// Shared driver-owned state held inside the `Endpoint`/`Service`/`Query`
+/// handles **and** the spawned driver task. The handle clones bump
+/// `Rc::strong_count`; the driver task uses `Rc::strong_count(&inner) == 1`
+/// as the "last external handle dropped" signal to exit (see [`run`]).
+pub(crate) struct EndpointInner {
+  pub(crate) state: RefCell<State>,
+  pub(crate) notify: LocalNotify,
+  /// Level-triggered "the driver has unserviced handle work" flag — the
+  /// driver-liveness invariant's single source of truth.
+  ///
+  /// WHY THIS EXISTS (do not replace it with bare `notify()`): the driver runs
+  /// an event loop that registers its `notify` listener only while parked in
+  /// `select!`. It spends most of each iteration `.await`ing socket sends, where
+  /// NO listener is armed. `event_listener::Event::notify()` does not latch — a
+  /// wake delivered with no listener registered is silently dropped. So a handle
+  /// op (`start_query`, `register_service`, a drop) that lands during a send is
+  /// invisible to the driver, which then parks: if that work contributed no
+  /// timer deadline (e.g. a timeout-less query), it parks FOREVER.
+  ///
+  /// `dirty` makes handle work durable across that window. Every handle op that
+  /// creates driver-actionable work calls [`Self::mark_dirty`], which sets this
+  /// AND notifies. The driver clears it at the top of each iteration before
+  /// pumping and forces an immediate re-settle (zero-duration timer) when it was
+  /// set — so the lost `notify` becomes a latency optimisation, never the sole
+  /// liveness guarantee. Work created during the pump re-sets `dirty` (caught
+  /// next iteration); work created during the park is caught by the listener.
+  ///
+  /// This replaces the previously-enumerated `force_now` cases
+  /// (`has_pending_withdrawal`, transmit-budget exhaustion, …) with one general
+  /// invariant — closing the lost-wake class for all current and future handle
+  /// operations by construction.
+  pub(crate) dirty: core::cell::Cell<bool>,
+}
+
+impl EndpointInner {
+  /// Build a fresh inner with empty proto state and a paired [`LocalNotify`].
+  /// Returned as `Rc<Self>` so the handle layer (T10+) can clone it without
+  /// re-wrapping. `dirty` starts `false`: no handle work exists until a handle
+  /// op runs.
+  pub(crate) fn new(cfg: EndpointConfig, max_payload: usize, max_recv: usize) -> Rc<Self> {
+    Rc::new(Self {
+      state: RefCell::new(State::new(cfg, max_payload, max_recv)),
+      notify: LocalNotify::new(),
+      dirty: core::cell::Cell::new(false),
+    })
+  }
+
+  /// Mark the driver dirty and wake it. EVERY handle operation that creates
+  /// driver-actionable work (start/register/cancel/withdraw) must call this
+  /// rather than `notify()` directly: the `notify` alone can be lost across the
+  /// driver's send-awaits (see [`Self::dirty`]); the flag is what guarantees the
+  /// work is observed. The notify is the latency optimisation layered on top.
+  #[inline]
+  pub(crate) fn mark_dirty(&self) {
+    self.dirty.set(true);
+    self.notify.notify();
+  }
+}
+
+/// Spawned driver future. Owns the compio sockets and runs until the last
+/// external [`Endpoint`] / [`Service`] / [`Query`] clone is dropped — detected
+/// by `Rc::strong_count(&inner) == 1`, meaning only this future's own Rc
+/// remains.
+///
+/// Borrow discipline: every interaction with `inner.state` happens inside a
+/// short `borrow()` / `borrow_mut()` scope that is dropped **before** any
+/// `.await`. The only `.await` points are `send_to`, `Socket::recv`,
+/// `compio::time::sleep`, and `LocalNotify::listen` — none of which run inside
+/// an open borrow.
+pub(crate) async fn run(
+  inner: Rc<EndpointInner>,
+  sock_v4: Option<Rc<Socket>>,
+  sock_v6: Option<Rc<Socket>>,
+) {
+  use futures::{FutureExt, future::Either};
+
+  // Scratch buffer reused across transmit-pump iterations. Sized from the
+  // caller-configured [`crate::ServerOptions::max_payload_size`] (default
+  // 1500, the Ethernet path MTU recommended by RFC 6762 §17 for outbound
+  // datagrams); the driver only writes the actual encoded length each pass.
+  //
+  // The recv buffer is sized from
+  // [`crate::ServerOptions::max_recv_packet_size`] (default 9000, the
+  // ceiling RFC 6762 §17 requires receivers to accept without truncation).
+  // Both are read off `state` once at startup — they are immutable for the
+  // lifetime of the driver.
+  let (mut scratch, max_recv) = {
+    let s = inner.state.borrow();
+    (vec![0u8; s.max_payload], s.max_recv)
+  };
+
+  loop {
+    // 1. extract-then-await transmit pump.  Borrow only long enough to pull
+    //    one datagram into `scratch`; drop the borrow before awaiting the
+    //    socket send.  The self-send record runs inside a second short
+    //    borrow after the send completes.
+    //
+    //    Bounded by [`MAX_TRANSMIT_CREDITS_PER_PASS`] (mirrors the reactor's
+    //    `MAX_SEND_CREDITS_PER_DRAIN`): when `poll_one_transmit` yields a
+    //    transmit for an address family WE never bound (e.g. v6 transmit
+    //    requested but only v4 socket present), `note_*_transmit_result`
+    //    is called with `delivered = false`, which re-arms the same transmit
+    //    rather than advancing lifecycle. Without a cap proto could keep
+    //    re-yielding it; the cap forces the loop to yield control to the
+    //    select! so timers / recv can make progress, and the deadline-driven
+    //    re-entry will retry.
+    let mut credits = MAX_TRANSMIT_CREDITS_PER_PASS;
+    loop {
+      if credits == 0 {
+        break;
+      }
+      credits -= 1;
+      let pumped = {
+        let mut s = inner.state.borrow_mut();
+        let now = StdInstant::now();
+        s.poll_one_transmit(now, &mut scratch)
+      };
+      let Some((dst, n, origin)) = pumped else {
+        break;
+      };
+      // `mdns-proto` always hands back the IPv4 multicast group for BOTH the
+      // v4 and v6 service groups (multicast_dst()), so we cannot route
+      // multicast by the destination's address family. Detect an mDNS
+      // multicast destination and fan the SAME body out to every bound
+      // family's multicast group (RFC 6762 §6); a dual-stack endpoint then
+      // reaches both `224.0.0.251` and `ff02::fb`, and a v6-only endpoint
+      // actually transmits (instead of routing to an absent v4 socket and
+      // marking the send undelivered).
+      //
+      // Self-send credit: record ONE tracker entry per ACTUAL successful
+      // send. Take-once self-suppression consumes a single entry per matching
+      // loopback, and dual-stack fan-out yields TWO loopback copies (one per
+      // joined socket), so a successful v4+v6 send records two entries.
+      //
+      // Timestamp: capture `when` IMMEDIATELY BEFORE each `.await`. compio is
+      // completion-based — the buffer moves into the op on `.await`, so we
+      // can't stamp "at the syscall" the way the readiness-I/O reactor does
+      // inside `poll_send_to`. Stamping before the await guarantees
+      // `when <= kernel_send_time <= echo_rx_time`, keeping our own loopback
+      // inside the 1 ms Ordered match window even when task-resume latency is
+      // high. (Stamping AFTER the await — the previous bug — could push the
+      // recorded time past the kernel's rx stamp and misclassify our own
+      // announce/probe as a peer packet.)
+      let delivered = if is_mdns_multicast_dst(dst) {
+        let mut sent_any = false;
+        if let Some(s4) = sock_v4.as_ref() {
+          let when = SystemTime::now();
+          if s4.send_to(&scratch[..n], MDNS_V4_DST, None).await.is_ok() {
+            let mut state = inner.state.borrow_mut();
+            crate::selfsend::record_self_send(&mut state.recent_sends, &scratch[..n], when);
+            sent_any = true;
+          }
+        }
+        if let Some(s6) = sock_v6.as_ref() {
+          let when = SystemTime::now();
+          if s6.send_to(&scratch[..n], MDNS_V6_DST, None).await.is_ok() {
+            let mut state = inner.state.borrow_mut();
+            crate::selfsend::record_self_send(&mut state.recent_sends, &scratch[..n], when);
+            sent_any = true;
+          }
+        }
+        // `delivered` ⇔ at least one family reached the wire.
+        sent_any
+      } else {
+        // Unicast: pick the socket matching the destination family, single
+        // send. No socket for this family → count as failed delivery so the
+        // proto re-arms the probe / announce without advancing lifecycle
+        // state (unchanged semantics).
+        let sock = match dst {
+          core::net::SocketAddr::V4(_) => sock_v4.as_ref(),
+          core::net::SocketAddr::V6(_) => sock_v6.as_ref(),
+        };
+        if let Some(s) = sock {
+          let when = SystemTime::now();
+          let res = s.send_to(&scratch[..n], dst, None).await;
+          // Record the self-send credit under a fresh short borrow so the next
+          // inbound copy of this datagram (from the loopback / multicast echo)
+          // is classified as our own.  Only record on a successful send.
+          if res.is_ok() {
+            let mut state = inner.state.borrow_mut();
+            crate::selfsend::record_self_send(&mut state.recent_sends, &scratch[..n], when);
+          }
+          res.is_ok()
+        } else {
+          false
+        }
+      };
+      // Confirm the pending transmit so the §8.1 probe sequence / §8.3 announce
+      // phase advance (services), or so the §5.2 backoff + retry budget
+      // advance only on a confirmed-delivered send (queries).  Anchored to
+      // post-send time so the next deadline is relative to actual on-wire send.
+      match origin {
+        TransmitOrigin::Service(h) => {
+          let mut state = inner.state.borrow_mut();
+          state.note_service_transmit_result(h, StdInstant::now(), delivered);
+        }
+        TransmitOrigin::Query(h) => {
+          let mut state = inner.state.borrow_mut();
+          state.note_query_transmit_result(h, StdInstant::now(), delivered);
+        }
+      }
+    }
+    // Exhausted the per-pass send budget — more transmits may be ready, so the
+    // driver must re-enter the pump rather than park until an unrelated event.
+    //
+    // Do NOT use `inner.notify.notify()` for this same-task re-entry: it is sent
+    // HERE, before the loop arms its next `notify_fut`, and `event-listener`
+    // does not latch a notification when no listener is active — so the wake
+    // would be lost and the 65th+ ready transmit could stall until an unrelated
+    // recv/timer/handle wake (codex R8). Instead carry an explicit flag into the
+    // pre-park timer decision below, which forces a zero-duration timer (the
+    // same lost-wake-proof mechanism used for pending withdrawals).
+    //
+    // This cannot busy-spin now that multicast transmits reach a bound socket:
+    // each successful send drives `note_*_transmit_result(delivered = true)`, so
+    // the proto advances (§8.1 probe / §8.3 announce) and the queue drains.
+    let pump_budget_exhausted = credits == 0;
+
+    // 1a-pre. Sweep services whose handle was dropped. `Service::drop` only
+    //     flags `cancelled`; the proto-state removal + §10.1 goodbye encoding
+    //     happens HERE, after the transmit pump, so a send that was in flight
+    //     when the handle dropped has already latched its records via
+    //     `note_service_transmit_result` and is therefore captured in the
+    //     goodbye. The freshly-queued goodbyes are sent by the 1a pump below in
+    //     this same iteration (their `next_at` is `now`).
+    {
+      let now = StdInstant::now();
+      inner.state.borrow_mut().sweep_cancelled_services(now);
+    }
+
+    // 1a. RFC 6762 §10.1 goodbye-burst pump. `sweep_cancelled_services` (and a
+    //     conflict-rename withdrawal) encode the TTL=0 records and push them
+    //     onto `state.goodbyes`; this loop fans each due entry out to BOTH
+    //     multicast families' sockets [`GOODBYE_SENDS`] times, spaced by
+    //     [`GOODBYE_INTERVAL`]. The borrow discipline matches the main pump:
+    //     snapshot the bytes under a brief borrow, send under no borrow, and
+    //     update remaining/next_at under another short borrow.
+    loop {
+      let now = StdInstant::now();
+      let due_entry: Option<(usize, Vec<u8>)> = {
+        let s = inner.state.borrow();
+        s.goodbyes
+          .iter()
+          .enumerate()
+          .find(|(_, g)| g.remaining > 0 && g.next_at <= now)
+          .map(|(i, g)| (i, g.data.clone()))
+      };
+      let Some((idx, data)) = due_entry else {
+        break;
+      };
+      // Fan out to every bound family on the mDNS multicast group.
+      // Capture `when` BEFORE each `.await` (completion-I/O equivalent of
+      // stamping at the syscall) so `when <= kernel_send_time <=
+      // echo_rx_time` and the kernel-looped goodbye stays inside the 1 ms
+      // Ordered self-send match window.
+      let mut sent_any = false;
+      if let Some(s4) = sock_v4.as_ref() {
+        let when = SystemTime::now();
+        if s4.send_to(&data, MDNS_V4_DST, None).await.is_ok() {
+          let mut state = inner.state.borrow_mut();
+          crate::selfsend::record_self_send(&mut state.recent_sends, &data, when);
+          sent_any = true;
+        }
+      }
+      if let Some(s6) = sock_v6.as_ref() {
+        let when = SystemTime::now();
+        if s6.send_to(&data, MDNS_V6_DST, None).await.is_ok() {
+          let mut state = inner.state.borrow_mut();
+          crate::selfsend::record_self_send(&mut state.recent_sends, &data, when);
+          sent_any = true;
+        }
+      }
+      let _ = sent_any; // Failure-to-send is logged via send_to's Result.
+      // Decrement remaining and re-arm next_at regardless of send outcome —
+      // an entry that can't reach the wire still drains its budget so it
+      // doesn't pin the goodbye queue forever.
+      {
+        let mut state = inner.state.borrow_mut();
+        if let Some(g) = state.goodbyes.get_mut(idx) {
+          g.remaining = g.remaining.saturating_sub(1);
+          g.next_at = now + GOODBYE_INTERVAL;
+        }
+      }
+    }
+    // GC fully drained goodbye entries.
+    {
+      let mut state = inner.state.borrow_mut();
+      state.goodbyes.retain(|g| g.remaining > 0);
+    }
+
+    // 1b. drain pending `ServiceUpdate`s out of each per-service proto state
+    //     machine and into the driver-side `ctx.updates` deque so listeners
+    //     parked on `Service::next` can pop them.  The borrow is brief and is
+    //     dropped before any `.await`.
+    {
+      let pushed = inner.state.borrow_mut().push_service_updates();
+      if pushed {
+        inner.notify.notify();
+      }
+    }
+
+    // 1b'. fire one-shot wakes for queries that just transitioned to `errored`
+    //      (un-encodable question, see `QueryCtx::errored`). Such a query has no
+    //      standing deadline, so this is the only wake that gets a parked
+    //      `Query::next` to observe its end-of-stream terminal.
+    {
+      let woke = inner.state.borrow_mut().take_query_terminal_wakes();
+      if woke {
+        inner.notify.notify();
+      }
+    }
+
+    // 1c. SHUTDOWN SETTLE (pre-park). All pending work for this iteration is now
+    //     drained (transmits, goodbye burst, cancellation sweep, updates). If no
+    //     external handle remains, exit — but FIRST flush every queued §10.1
+    //     goodbye so a withdrawal is never lost at teardown.
+    //
+    //     This check lives HERE, before arming `select!`, not after the park.
+    //     `Service::drop` / `Query::drop` only flag + `notify()`, and the shared
+    //     `LocalNotify` wake is LOST if it lands while the driver is mid-`send_to`
+    //     await with no listener armed. A bottom-of-loop, post-park shutdown
+    //     check therefore raced last-handle drops: the loop could park forever
+    //     (task + sockets leaked) or defer the goodbye to some unrelated later
+    //     wake. Settling pre-park makes the last-handle exit deterministic and
+    //     independent of whether that notify was delivered.
+    if Rc::strong_count(&inner) == 1 {
+      let datagrams = {
+        let now = StdInstant::now();
+        inner.state.borrow_mut().take_shutdown_goodbyes(now)
+      };
+      for data in datagrams {
+        if let Some(s4) = sock_v4.as_ref() {
+          let _ = s4.send_to(&data, MDNS_V4_DST, None).await;
+        }
+        if let Some(s6) = sock_v6.as_ref() {
+          let _ = s6.send_to(&data, MDNS_V6_DST, None).await;
+        }
+      }
+      break;
+    }
+
+    // 2. compute the next deadline, and decide whether to re-settle IMMEDIATELY
+    //    (zero-duration timer) instead of parking. `force_now` is the
+    //    driver-liveness guard, and both its sources are lost-wake-proof because
+    //    they go through the TIMER, not `LocalNotify`:
+    //
+    //    * `dirty` — a handle op created work that hasn't been serviced. CRUCIAL:
+    //      this is consumed HERE, at the pre-park boundary, AFTER every awaitable
+    //      pump above — NOT at loop entry. A handle's `mark_dirty` can land during
+    //      a LATE pump await (e.g. the §10.1 goodbye `send_to().await`), after a
+    //      loop-entry sample would already have been taken; reading `dirty` here
+    //      catches that. Everything from this `replace(false)` to arming the
+    //      `select!` listener below is synchronous (no `.await`), so a `dirty` set
+    //      before this read forces an immediate re-settle, and one set after is
+    //      caught by the now-armed listener — no gap. This single level signal
+    //      subsumes the previously-enumerated cases (pending withdrawal,
+    //      newly-started timeout-less query, …): every work-creating handle op
+    //      marks the endpoint dirty (see `EndpointInner::mark_dirty`), closing the
+    //      "handle parks forever" lost-wake class by construction.
+    //    * `pump_budget_exhausted` — the transmit pump hit its per-pass credit
+    //      cap with work still queued; re-enter to drain the backlog.
+    let deadline = { inner.state.borrow().poll_deadline() };
+    let force_now = inner.dirty.replace(false) || pump_budget_exhausted;
+
+    // 3. arm the timer future. `Either<sleep, pending>` keeps both arms with
+    //    the same `Output = ()` so a single `pin_mut!` is enough for
+    //    `select!` to accept either branch via the fused wrapper.
+    let timer_fut = match (force_now, deadline) {
+      (true, _) => Either::Left(compio::time::sleep(Duration::ZERO)),
+      (false, Some(at)) => {
+        let dur = at.saturating_duration_since(StdInstant::now());
+        Either::Left(compio::time::sleep(dur))
+      }
+      (false, None) => Either::Right(core::future::pending::<()>()),
+    }
+    .fuse();
+    futures::pin_mut!(timer_fut);
+
+    // 4. arm the notify future. `LocalNotify::listen` is awaitable directly;
+    //    fuse it so `select!` accepts it.
+    let notify_fut = inner.notify.listen().fuse();
+    futures::pin_mut!(notify_fut);
+
+    // 5. arm one recv future per bound family. The recv future borrows from
+    //    its socket and owns its data + control buffers across the
+    //    completion; if `select!` picks another arm the recv future is
+    //    dropped, taking the in-flight buffers with it.
+    //
+    // After a timer or recv arm fires the driver's own listener is consumed,
+    // but user-side handles (`Service::next`, `Query::next`) may still be
+    // parked on `inner.notify.listen()` — they need a wake to re-check the
+    // proto state.  Bump notify whenever timer/recv may have advanced state.
+    let mut woke_state = false;
+    match (sock_v4.as_ref(), sock_v6.as_ref()) {
+      (Some(s4), Some(s6)) => {
+        let r4 = s4.recv(max_recv).fuse();
+        let r6 = s6.recv(max_recv).fuse();
+        futures::pin_mut!(r4, r6);
+        futures::select! {
+          r = r4 => { handle_recv(&inner, r); woke_state = true; }
+          r = r6 => { handle_recv(&inner, r); woke_state = true; }
+          _ = timer_fut => { inner.state.borrow_mut().fire_timeouts(StdInstant::now()); woke_state = true; }
+          _ = notify_fut => {}
+        }
+      }
+      (Some(s4), None) => {
+        let r4 = s4.recv(max_recv).fuse();
+        futures::pin_mut!(r4);
+        futures::select! {
+          r = r4 => { handle_recv(&inner, r); woke_state = true; }
+          _ = timer_fut => { inner.state.borrow_mut().fire_timeouts(StdInstant::now()); woke_state = true; }
+          _ = notify_fut => {}
+        }
+      }
+      (None, Some(s6)) => {
+        let r6 = s6.recv(max_recv).fuse();
+        futures::pin_mut!(r6);
+        futures::select! {
+          r = r6 => { handle_recv(&inner, r); woke_state = true; }
+          _ = timer_fut => { inner.state.borrow_mut().fire_timeouts(StdInstant::now()); woke_state = true; }
+          _ = notify_fut => {}
+        }
+      }
+      (None, None) => {
+        // No sockets — just wait on timer/notify so the driver doesn't
+        // busy-spin.
+        futures::select! {
+          _ = timer_fut => { inner.state.borrow_mut().fire_timeouts(StdInstant::now()); woke_state = true; }
+          _ = notify_fut => {}
+        }
+      }
+    }
+    if woke_state {
+      inner.notify.notify();
+    }
+  }
+}
+
+#[inline]
+fn handle_recv(inner: &Rc<EndpointInner>, r: std::io::Result<(Vec<u8>, RecvMeta)>) {
+  if let Ok((data, meta)) = r {
+    let mut s = inner.state.borrow_mut();
+    s.handle_datagram(&meta, &data);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use core::cell::Cell;
+  use std::rc::Rc;
+
+  use super::*;
+
+  #[compio::test]
+  async fn local_notify_wakes_a_listener() {
+    let n = LocalNotify::new();
+    let woken = Rc::new(Cell::new(false));
+    let woken_in = woken.clone();
+    let n2 = n.clone();
+    compio_runtime::spawn(async move {
+      n2.listen().await;
+      woken_in.set(true);
+    })
+    .detach();
+    // give the listener a chance to register
+    compio::time::sleep(std::time::Duration::from_millis(10)).await;
+    n.notify();
+    compio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(woken.get(), "listener woken by notify()");
+  }
+
+  /// `is_mdns_multicast_dst` must accept BOTH multicast service groups on
+  /// port 5353 (so the transmit pump fans out to both families) and reject
+  /// unicast destinations and the wrong port — proto's `multicast_dst()`
+  /// always hands back the v4 group, so a false negative here would silence
+  /// the v6 leg of every multicast send.
+  #[test]
+  fn is_mdns_multicast_dst_classifies_groups_and_ports() {
+    use core::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+    // v4 group on 5353 → true
+    assert!(is_mdns_multicast_dst(SocketAddr::V4(SocketAddrV4::new(
+      Ipv4Addr::new(224, 0, 0, 251),
+      5353
+    ))));
+    // v6 group on 5353 → true
+    assert!(is_mdns_multicast_dst(SocketAddr::V6(SocketAddrV6::new(
+      Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0x00fb),
+      5353,
+      0,
+      0
+    ))));
+    // unicast on 5353 → false
+    assert!(!is_mdns_multicast_dst(SocketAddr::V4(SocketAddrV4::new(
+      Ipv4Addr::new(192, 168, 1, 5),
+      5353
+    ))));
+    // v4 group on the wrong port → false
+    assert!(!is_mdns_multicast_dst(SocketAddr::V4(SocketAddrV4::new(
+      Ipv4Addr::new(224, 0, 0, 251),
+      53
+    ))));
+  }
+
+  #[test]
+  fn state_construction_is_empty() {
+    let s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    assert_eq!(s.services.len(), 0);
+    assert_eq!(s.queries.len(), 0);
+    assert!(s.goodbyes.is_empty());
+  }
+
+  #[test]
+  fn fire_timeouts_runs_without_panic_on_empty_state() {
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    s.fire_timeouts(std::time::Instant::now());
+  }
+
+  #[compio::test]
+  async fn endpoint_inner_can_be_constructed_and_dropped() {
+    let cfg = mdns_proto::EndpointConfig::default();
+    let inner = EndpointInner::new(cfg, 1500, 9000);
+    // notify can be cloned and listened on without panicking
+    let n = inner.notify.clone();
+    // sanity: listening + notifying once doesn't deadlock
+    let h = compio_runtime::spawn(async move {
+      n.listen().await;
+    });
+    compio::time::sleep(std::time::Duration::from_millis(5)).await;
+    inner.notify.notify();
+    h.await.ok();
+    drop(inner);
+  }
+
+  /// Driver-liveness invariant (codex R9 + R10): `mark_dirty` is the durable
+  /// signal a handle op uses to guarantee the driver re-settles even if the
+  /// paired `notify` is lost across a send-await. This pins the mechanics the run
+  /// loop's PRE-PARK `inner.dirty.replace(false)` + `force_now` depend on:
+  /// `dirty` starts clear, `mark_dirty` sets it, and the consume both reads the
+  /// pending state AND clears it. Critically the consume happens at the PARK
+  /// BOUNDARY (after every awaitable pump), not at loop entry — R10 found that a
+  /// loop-entry sample misses a `mark_dirty` landing during a late pump await
+  /// (e.g. the goodbye send); reading at the boundary, with no `.await` between
+  /// the read and arming the `select!` listener, closes that window with no gap.
+  #[test]
+  fn mark_dirty_sets_a_durable_level_flag_consumed_by_replace() {
+    let inner = EndpointInner::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    // Fresh endpoint: no handle work yet.
+    assert!(!inner.dirty.get(), "dirty must start clear");
+
+    // A handle op marks the endpoint dirty (durably — independent of whether any
+    // listener is armed, unlike a bare notify).
+    inner.mark_dirty();
+    assert!(inner.dirty.get(), "mark_dirty must set the level flag");
+
+    // The driver's pre-park consume reads `true` (→ force_now re-settle) and
+    // clears it in one step.
+    let force_now = inner.dirty.replace(false);
+    assert!(
+      force_now,
+      "the pre-park decision must observe the pending work"
+    );
+    assert!(
+      !inner.dirty.get(),
+      "consuming the flag clears it so a clean iteration can park"
+    );
+
+    // A second consume with no intervening mark sees nothing — no spurious
+    // force_now / busy-spin once the work is serviced.
+    assert!(
+      !inner.dirty.replace(false),
+      "no work created since last consume → not dirty → driver may park"
+    );
+
+    // Work created AFTER the consume (e.g. a handle op racing a late pump await)
+    // re-sets the flag, so the NEXT pre-park consume observes it rather than
+    // losing it.
+    inner.mark_dirty();
+    assert!(
+      inner.dirty.replace(false),
+      "work created after the previous consume must be observed at the next park boundary"
+    );
+  }
+
+  /// §11 regression guard: a datagram whose TTL/hop-limit is < 255 and whose
+  /// source address falls outside the cached local-subnet snapshot must be
+  /// dropped by `handle_datagram` before it ever reaches `endpoint.handle`.
+  /// We can't observe the proto-side call externally, so the assertion is
+  /// "the call returns without panicking on a deliberately bogus 12-byte
+  /// body" — which is only true if the §11 gate early-returns first.
+  #[test]
+  fn handle_datagram_drops_off_link_packet() {
+    use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use crate::socket::RecvMeta;
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    s.local_subnets = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)), 8)];
+    s.bound_interface = 1;
+    let meta = RecvMeta {
+      peer: SocketAddr::from(([8, 8, 8, 8], 5353)),
+      local_ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+      interface_index: 1,
+      hop_limit: Some(64), // off-link: not 255
+      kernel_rx_time: None,
+      len: 12,
+    };
+    let data = vec![0u8; 12];
+    // The §11 gate must drop this off-link datagram silently — no panic,
+    // and crucially no unwind from `endpoint.handle` chewing on the bogus
+    // 12-byte header (which would happen if the gate let it through).
+    s.handle_datagram(&meta, &data);
+  }
+
+  /// `remove_service` MUST: (a) free the proto-layer route slot so re-
+  /// registering the same instance name doesn't surface
+  /// `NameAlreadyRegistered`, (b) evict the driver-side `ServiceCtx` from
+  /// `state.services`, and (c) queue a TTL=0 goodbye burst for any
+  /// confirmed-emitted records — the RFC 6762 §10.1 graceful-withdrawal
+  /// contract.  Without (a) + (b) every dropped service permanently leaks a
+  /// slot until endpoint shutdown.
+  #[test]
+  fn remove_service_queues_goodbye_and_frees_proto_slot() {
+    use std::time::Duration;
+
+    use mdns_proto::{Name, ServiceRecords, ServiceSpec};
+
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let mut t = std::time::Instant::now();
+
+    let stype = Name::try_from_str("_gb._tcp.local.").unwrap();
+    let inst = Name::try_from_str("G._gb._tcp.local.").unwrap();
+    let host = Name::try_from_str("g.local.").unwrap();
+    let mut recs = ServiceRecords::new(stype, inst.clone(), host, 1234, 120);
+    recs.add_a([127, 0, 0, 1].into());
+    let handle = s.register_service(ServiceSpec::new(recs), t).unwrap();
+
+    // Drive the proto state machine through probe + announce so the goodbye
+    // ownership latches are set — otherwise `encode_goodbye` returns
+    // `Ok(None)` and nothing is queued.  Each `poll_transmit` stamps the
+    // commit token; `note_transmit_delivered` advances the lifecycle.
+    let mut buf = vec![0u8; 4096];
+    for _ in 0..40 {
+      t += Duration::from_millis(300);
+      let ctx = s.services.get_mut(&handle).unwrap();
+      let _ = ctx.proto.handle_timeout(t);
+      while let Ok(Some(_)) = ctx.proto.poll_transmit(t, &mut buf) {
+        ctx.proto.note_transmit_delivered(t);
+      }
+    }
+    // Sanity: the service did reach a state that advertises records.
+    assert!(
+      s.services
+        .get(&handle)
+        .map(|c| c.proto.advertises_host())
+        .unwrap_or(false),
+      "service must have advertised at least one record before removal"
+    );
+
+    // Remove: the driver-side ctx must vanish AND a goodbye must be queued.
+    s.remove_service(handle, t);
+    assert!(
+      !s.services.contains_key(&handle),
+      "remove_service must evict the driver-side ServiceCtx"
+    );
+    assert!(
+      !s.goodbyes.is_empty(),
+      "remove_service must queue a TTL=0 goodbye for the confirmed-emitted records"
+    );
+    let g = &s.goodbyes[0];
+    assert_eq!(
+      g.remaining, GOODBYE_SENDS,
+      "burst budget must be initialised"
+    );
+    // The proto-layer route slot must be released too: re-registering the
+    // same instance name must succeed (otherwise we'd hit NameAlreadyRegistered).
+    let mut recs2 = ServiceRecords::new(
+      Name::try_from_str("_gb._tcp.local.").unwrap(),
+      inst,
+      Name::try_from_str("g.local.").unwrap(),
+      1234,
+      120,
+    );
+    recs2.add_a([127, 0, 0, 1].into());
+    assert!(
+      s.register_service(ServiceSpec::new(recs2), t).is_ok(),
+      "the proto-layer route slot must be freed by remove_service"
+    );
+  }
+
+  /// `Service::drop` must NOT remove the proto state or encode the goodbye
+  /// synchronously — it only flags `cancelled` (via `flag_service_unregistered`).
+  /// The driver's post-pump `sweep_cancelled_services` is what evicts the entry
+  /// and queues the §10.1 goodbye. This split is load-bearing: it lets a send
+  /// that was in flight when the handle dropped latch its records (via
+  /// `note_service_transmit_result`) BEFORE the goodbye is encoded, so a service
+  /// dropped mid-send still withdraws every record it actually put on the wire.
+  #[compio::test]
+  async fn drop_defers_goodbye_to_driver_sweep() {
+    use mdns_proto::{Name, ServiceRecords, ServiceSpec};
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let mut t = std::time::Instant::now();
+    let stype = Name::try_from_str("_sw._tcp.local.").unwrap();
+    let inst = Name::try_from_str("s._sw._tcp.local.").unwrap();
+    let host = Name::try_from_str("s.local.").unwrap();
+    let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+    recs.add_a([127, 0, 0, 1].into());
+    let handle = s.register_service(ServiceSpec::new(recs), t).unwrap();
+
+    // Drive probe + announce so the service has confirmed-emitted records.
+    let mut buf = vec![0u8; 4096];
+    for _ in 0..40 {
+      t += Duration::from_millis(300);
+      let ctx = s.services.get_mut(&handle).unwrap();
+      let _ = ctx.proto.handle_timeout(t);
+      while let Ok(Some(_)) = ctx.proto.poll_transmit(t, &mut buf) {
+        ctx.proto.note_transmit_delivered(t);
+      }
+    }
+    assert!(
+      s.services
+        .get(&handle)
+        .map(|c| c.proto.advertises_host())
+        .unwrap_or(false),
+      "service must advertise before withdrawal"
+    );
+
+    // What `Service::drop` does — flag only, no removal, no goodbye encoding.
+    s.flag_service_unregistered(handle);
+    assert!(
+      s.services.contains_key(&handle),
+      "drop must NOT remove the service synchronously"
+    );
+    assert!(
+      s.goodbyes.is_empty(),
+      "drop must NOT encode the goodbye synchronously — the driver sweep does"
+    );
+    assert!(
+      s.services
+        .get(&handle)
+        .map(|c| c.cancelled)
+        .unwrap_or(false),
+      "the service must be flagged cancelled"
+    );
+
+    // `has_pending_withdrawal` must report the cancelled-but-unswept service so
+    // the driver forces an immediate wake instead of parking (the lost-notify
+    // guard): a drop's `notify` can be lost mid-`send_to`, so the forced timer
+    // is what guarantees the next iteration sweeps + sends the goodbye.
+    assert!(
+      s.has_pending_withdrawal(),
+      "a cancelled-but-unswept service must report a pending withdrawal"
+    );
+
+    // What the driver's post-pump sweep does — evict + queue the §10.1 goodbye.
+    let swept = s.sweep_cancelled_services(t);
+    assert!(swept, "sweep must report it removed a cancelled service");
+    assert!(
+      !s.services.contains_key(&handle),
+      "sweep must evict the cancelled service's ServiceCtx"
+    );
+    assert!(
+      !s.goodbyes.is_empty(),
+      "sweep must queue a TTL=0 goodbye for the confirmed-emitted records"
+    );
+    assert!(
+      !s.has_pending_withdrawal(),
+      "after the sweep there is no pending withdrawal left"
+    );
+  }
+
+  /// On the last-handle-drop shutdown path the driver can't stay alive for the
+  /// timer-spaced goodbye bursts, so it calls `take_shutdown_goodbyes`: this
+  /// must (a) sweep a service that was flagged cancelled but never swept (the
+  /// race codex R4 found — the shutdown check would otherwise exit before the
+  /// next top-of-loop sweep) and (b) drain every queued burst into a flat
+  /// datagram list so all TTL=0 copies reach the wire before exit, leaving the
+  /// goodbye queue empty.
+  #[compio::test]
+  async fn shutdown_drain_sweeps_and_flushes_all_bursts() {
+    use mdns_proto::{Name, ServiceRecords, ServiceSpec};
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let mut t = std::time::Instant::now();
+    let stype = Name::try_from_str("_sd._tcp.local.").unwrap();
+    let inst = Name::try_from_str("s._sd._tcp.local.").unwrap();
+    let host = Name::try_from_str("s.local.").unwrap();
+    let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+    recs.add_a([127, 0, 0, 1].into());
+    let handle = s.register_service(ServiceSpec::new(recs), t).unwrap();
+
+    let mut buf = vec![0u8; 4096];
+    for _ in 0..40 {
+      t += Duration::from_millis(300);
+      let ctx = s.services.get_mut(&handle).unwrap();
+      let _ = ctx.proto.handle_timeout(t);
+      while let Ok(Some(_)) = ctx.proto.poll_transmit(t, &mut buf) {
+        ctx.proto.note_transmit_delivered(t);
+      }
+    }
+    assert!(
+      s.services
+        .get(&handle)
+        .map(|c| c.proto.advertises_host())
+        .unwrap_or(false),
+      "service must advertise before withdrawal"
+    );
+
+    // Service::drop on the last handle: flag only. The sweep never ran (the
+    // driver is about to exit), so the shutdown drain must cover it.
+    s.flag_service_unregistered(handle);
+
+    let datagrams = s.take_shutdown_goodbyes(t);
+    assert!(
+      !s.services.contains_key(&handle),
+      "shutdown drain must sweep the cancelled service"
+    );
+    assert!(
+      s.goodbyes.is_empty(),
+      "shutdown drain must leave the goodbye queue empty"
+    );
+    // One service worth of goodbye, expanded to its full burst count.
+    assert_eq!(
+      datagrams.len(),
+      GOODBYE_SENDS as usize,
+      "every remaining burst copy must be flushed back-to-back, got {}",
+      datagrams.len()
+    );
+    assert!(
+      datagrams.iter().all(|d| !d.is_empty()),
+      "flushed goodbye datagrams must be non-empty"
+    );
+  }
+
+  /// `poll_deadline` must include pending goodbyes' `next_at` so the driver
+  /// wakes to fan out a queued §10.1 burst even when no other deadline is
+  /// pending.  A regression here would let a goodbye burst silently stall
+  /// after the first send.
+  #[test]
+  fn poll_deadline_sees_pending_goodbye() {
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let now = std::time::Instant::now();
+    assert!(s.poll_deadline().is_none(), "empty state has no deadline");
+    s.goodbyes.push(PendingGoodbye {
+      data: vec![0xde, 0xad],
+      remaining: GOODBYE_SENDS,
+      next_at: now,
+    });
+    assert_eq!(
+      s.poll_deadline(),
+      Some(now),
+      "a queued goodbye must surface its next_at on poll_deadline"
+    );
+  }
+
+  /// Build a `ServiceUpdate::Renamed` carrying `name` (a `*.local.` instance
+  /// name). `ServiceRenamed::new` is `#[doc(hidden)]` but public — the same
+  /// constructor the reactor's tests use to synthesize renames.
+  fn renamed(name: &str) -> ServiceUpdate {
+    ServiceUpdate::Renamed(mdns_proto::ServiceRenamed::new(
+      mdns_proto::Name::try_from_str(name).unwrap(),
+    ))
+  }
+
+  /// One-time/idempotent kinds (`Established` / `Conflict` / `HostConflict`)
+  /// must dedup by kind: repeated pushes of the same kind never grow the
+  /// deque past one entry of that kind. This is the core memory-DoS guard —
+  /// a peer spamming conflict-bearing packets can't inflate the queue.
+  #[test]
+  fn coalesce_dedups_one_time_kinds() {
+    let mut d: VecDeque<ServiceUpdate> = VecDeque::new();
+
+    for _ in 0..5 {
+      push_service_update_coalesced(&mut d, ServiceUpdate::Established);
+    }
+    assert_eq!(d.len(), 1, "Established must dedup to a single entry");
+
+    for _ in 0..3 {
+      push_service_update_coalesced(&mut d, ServiceUpdate::Conflict);
+    }
+    assert_eq!(
+      d.iter()
+        .filter(|u| matches!(u, ServiceUpdate::Conflict))
+        .count(),
+      1,
+      "Conflict must be present exactly once after 3 pushes"
+    );
+
+    push_service_update_coalesced(&mut d, ServiceUpdate::HostConflict);
+    push_service_update_coalesced(&mut d, ServiceUpdate::HostConflict);
+    assert_eq!(
+      d.iter()
+        .filter(|u| matches!(u, ServiceUpdate::HostConflict))
+        .count(),
+      1,
+      "HostConflict must be present exactly once"
+    );
+
+    // Established + Conflict + HostConflict = 3 distinct kinds, one each.
+    assert_eq!(d.len(), 3, "three distinct one-time kinds, one entry each");
+  }
+
+  /// A new `Renamed` must drop any prior pending `Renamed` and re-append at the
+  /// back, so the deque keeps exactly one rename carrying the LATEST name —
+  /// the only one the caller acts on.
+  #[test]
+  fn coalesce_keeps_latest_rename() {
+    let mut d: VecDeque<ServiceUpdate> = VecDeque::new();
+    push_service_update_coalesced(&mut d, renamed("a.local."));
+    push_service_update_coalesced(&mut d, renamed("b.local."));
+
+    assert_eq!(
+      d.iter()
+        .filter(|u| matches!(u, ServiceUpdate::Renamed(_)))
+        .count(),
+      1,
+      "only the latest Renamed must remain"
+    );
+    match d.back() {
+      Some(ServiceUpdate::Renamed(r)) => {
+        assert_eq!(
+          r.new_name().as_str(),
+          "b.local.",
+          "the surviving Renamed must carry the latest name"
+        );
+      }
+      other => panic!("expected a Renamed at the back, got {other:?}"),
+    }
+  }
+
+  /// RFC 6762 §9 conflict path: a service reaches `Established`, a peer
+  /// conflict drives a `Renamed`, then the renamed service re-announces and the
+  /// proto emits a SECOND `Established`. The coalescer must surface that final
+  /// `Established` — dropping the STALE first one and keeping the new one. A
+  /// by-kind-keep-first policy would wrongly discard the post-rename
+  /// confirmation that the renamed service is now advertised.
+  #[test]
+  fn coalesce_keeps_post_rename_established() {
+    let mut d: VecDeque<ServiceUpdate> = VecDeque::new();
+    push_service_update_coalesced(&mut d, ServiceUpdate::Established);
+    push_service_update_coalesced(&mut d, renamed("renamed.local."));
+    push_service_update_coalesced(&mut d, ServiceUpdate::Established);
+
+    assert!(
+      d.iter().any(|u| matches!(u, ServiceUpdate::Established)),
+      "post-rename Established must survive coalescing, got {d:?}"
+    );
+    assert!(
+      d.iter().any(|u| matches!(u, ServiceUpdate::Renamed(_))),
+      "the rename must also survive, got {d:?}"
+    );
+    assert_eq!(
+      d.iter()
+        .filter(|u| matches!(u, ServiceUpdate::Established))
+        .count(),
+      1,
+      "exactly one Established retained (latest), got {d:?}"
+    );
+  }
+
+  /// Under realistic churn — a peer interleaving every update kind many times —
+  /// the deque must stay bounded to the ≤4-distinct-kinds invariant.
+  #[test]
+  fn coalesce_bounds_total() {
+    let mut d: VecDeque<ServiceUpdate> = VecDeque::new();
+    for i in 0..50 {
+      push_service_update_coalesced(&mut d, ServiceUpdate::Established);
+      push_service_update_coalesced(&mut d, ServiceUpdate::Conflict);
+      push_service_update_coalesced(&mut d, ServiceUpdate::HostConflict);
+      push_service_update_coalesced(&mut d, renamed(&format!("r-{i}.local.")));
+    }
+    assert!(
+      d.len() <= 4,
+      "coalesced deque must stay within the ≤4-kind bound, got {}",
+      d.len()
+    );
+  }
+
+  /// codex R6 transmit-liveness regression: a service whose records cannot be
+  /// encoded into the configured `max_payload` must NOT silently stall. The
+  /// proto PRESERVES the un-encodable pending transmit (re-offering it every
+  /// `poll_transmit`), so the prior `if let Ok(Some(_))` arm — which treated the
+  /// `Err(TransmitError::BufferTooSmall)` like `Ok(None)` — left the service
+  /// stuck below `Established` forever with no `ServiceUpdate` ever delivered.
+  ///
+  /// The fix counts consecutive encode failures per service and, at
+  /// [`MAX_CONSECUTIVE_ENCODE_ERRORS`], escalates to `ServiceUpdate::Conflict`
+  /// (queued in the in-ctx `updates` deque, NOT dropped) and flags the service
+  /// `errored` so it is skipped by every later proto-polling pump. This test
+  /// drives `poll_one_transmit` with a deliberately tiny scratch buffer and
+  /// asserts: (a) the failure counter climbs one per call, (b) at the threshold
+  /// a `Conflict` lands in `updates` and `errored` is set, and (c) a subsequent
+  /// `poll_one_transmit` skips the errored service (returns `None` when it's the
+  /// only one) rather than re-polling its dead proto.
+  #[test]
+  fn oversized_service_escalates_to_conflict_not_silent_stall() {
+    use mdns_proto::{Name, ServiceRecords, ServiceSpec};
+
+    // `max_payload` is irrelevant to `poll_one_transmit` (it takes `scratch`
+    // explicitly); a real-record service is what matters.
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1, 9000);
+    let now = std::time::Instant::now();
+
+    // A realistic record set: PTR + SRV (implied by `new`) + TXT + A + AAAA.
+    let stype = Name::try_from_str("_ovf._tcp.local.").unwrap();
+    let inst = Name::try_from_str("Oversized._ovf._tcp.local.").unwrap();
+    let host = Name::try_from_str("oversized.local.").unwrap();
+    let mut recs = ServiceRecords::new(stype, inst, host, 8080, 120);
+    recs.add_a([192, 168, 1, 42].into());
+    recs.add_aaaa([0xfe80, 0, 0, 0, 0, 0, 0, 0x1234].into());
+    recs.add_txt_segment(b"path=/health".to_vec());
+    let handle = s.register_service(ServiceSpec::new(recs), now).unwrap();
+
+    // A 1-byte scratch buffer guarantees `proto.poll_transmit` returns
+    // `Err(BufferTooSmall)` once a probe is queued (a probe is many bytes).
+    // Verified empirically: the proto needs the probe PENDING first — a fresh
+    // service is in `Init` with no queued transmit, so the first few
+    // `poll_one_transmit` calls would see `Ok(None)` (reset to 0). We therefore
+    // PRIME the lifecycle: advance the clock and `fire_timeouts` until the proto
+    // pushes its first probe (Init → Probing(0) → probe pending), detected by
+    // the failure counter ticking to 1. Mirrors the time-advancing drive loop
+    // the existing `remove_service` / shutdown tests use, but stops at the first
+    // encode failure instead of delivering the transmit.
+    let mut scratch = [0u8; 1];
+    let mut t = now;
+    let mut armed = false;
+    for _ in 0..40 {
+      t += Duration::from_millis(300);
+      s.fire_timeouts(t);
+      // A failing poll increments `encode_failures`; an `Ok(None)` (nothing
+      // pending yet) resets it to 0. Once the probe is queued this sticks at 1.
+      let pumped = s.poll_one_transmit(t, &mut scratch);
+      assert!(
+        pumped.is_none(),
+        "an un-encodable transmit must never be returned as a phantom send"
+      );
+      if s.services.get(&handle).unwrap().encode_failures == 1 {
+        armed = true;
+        break;
+      }
+    }
+    assert!(
+      armed,
+      "the proto must queue a probe that fails to encode into the 1-byte scratch"
+    );
+
+    // With the probe queued and `Err` preserving it (the proto does NOT pop an
+    // un-encodable transmit), each further `poll_one_transmit` must fail again
+    // and bump the counter by exactly one — no `fire_timeouts` needed between
+    // them. Drive it the rest of the way to the escalation threshold.
+    for expected in 2..=MAX_CONSECUTIVE_ENCODE_ERRORS {
+      let pumped = s.poll_one_transmit(t, &mut scratch);
+      assert!(
+        pumped.is_none(),
+        "an un-encodable transmit must never be returned as a phantom send \
+         (failure #{expected})"
+      );
+      assert_eq!(
+        s.services.get(&handle).unwrap().encode_failures,
+        expected,
+        "each failing poll must increment encode_failures by one"
+      );
+    }
+
+    // At the threshold the service must be escalated: a `Conflict` queued in the
+    // in-ctx deque, the terminal `errored` flag set, and the one-shot wake armed.
+    {
+      let ctx = s.services.get(&handle).unwrap();
+      assert!(
+        ctx.errored,
+        "reaching MAX_CONSECUTIVE_ENCODE_ERRORS must mark the service errored"
+      );
+      assert!(
+        ctx
+          .updates
+          .iter()
+          .any(|u| matches!(u, ServiceUpdate::Conflict)),
+        "the escalation must queue a ServiceUpdate::Conflict for Service::next, \
+         got {:?}",
+        ctx.updates
+      );
+      assert!(
+        ctx.conflict_wake_pending,
+        "the escalation must arm the one-shot wake so a parked handle is notified"
+      );
+    }
+
+    // A subsequent pump must SKIP the errored service. With it the only
+    // registered service (and no queries), the result is `None` — proving the
+    // dead proto is no longer re-polled (no busy-spin) and the counter is frozen.
+    assert!(
+      s.poll_one_transmit(now, &mut scratch).is_none(),
+      "an errored service must be skipped by poll_one_transmit"
+    );
+    assert_eq!(
+      s.services.get(&handle).unwrap().encode_failures,
+      MAX_CONSECUTIVE_ENCODE_ERRORS,
+      "a skipped errored service must not have its failure counter advanced further"
+    );
+
+    // `push_service_updates` must consume the one-shot wake exactly once (so a
+    // parked handle is woken), then report no further wake for the same queued
+    // Conflict — i.e. an undrained Conflict cannot drive a notify busy-spin.
+    assert!(
+      s.push_service_updates(),
+      "push_service_updates must report a wake for the freshly-escalated Conflict"
+    );
+    assert!(
+      !s.services.get(&handle).unwrap().conflict_wake_pending,
+      "the one-shot wake flag must be cleared after the single notify"
+    );
+    assert!(
+      !s.push_service_updates(),
+      "a second push must NOT re-wake for the same undrained Conflict (no spin)"
+    );
+    // The Conflict is still queued for the handle to drain.
+    assert!(
+      s.services
+        .get(&handle)
+        .unwrap()
+        .updates
+        .iter()
+        .any(|u| matches!(u, ServiceUpdate::Conflict)),
+      "the queued Conflict must remain readable by Service::next after the wake"
+    );
+  }
+
+  /// codex R7: a query whose question can't be encoded into `max_payload` (here
+  /// a 1-byte scratch) must be flagged `errored` rather than re-offered forever.
+  /// A fresh query has `transmit_pending = true`, so the first
+  /// `poll_one_transmit` attempts the encode and fails. The driver must mark the
+  /// query errored (so every pump skips it — no busy-spin), arm the one-shot
+  /// terminal wake exactly once, and contribute no deadline. Without this, a
+  /// `QuerySpec` with the default `timeout: None` has neither a `timeout_deadline`
+  /// nor (post-failure) a `next_deadline`, so `poll_deadline` returns `None` and
+  /// a parked `Query::next` would hang indefinitely.
+  #[test]
+  fn unencodable_query_is_errored_not_spun_or_hung() {
+    use mdns_proto::{QuerySpec, wire::ResourceType};
+
+    let mut s = State::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let now = std::time::Instant::now();
+    let qname = mdns_proto::Name::try_from_str("printer.local.").unwrap();
+    // Default QuerySpec: no timeout → no absolute deadline. This is the case
+    // that hangs without the fix.
+    let h = s
+      .start_query(QuerySpec::new(qname, ResourceType::A), now)
+      .unwrap();
+
+    // A 1-byte scratch can't hold a DNS header + question → encode `Err`.
+    let mut scratch = [0u8; 1];
+
+    // First pump: the pending question fails to encode. The query must be
+    // flagged errored and yield NO transmit (not a phantom send).
+    let pumped = s.poll_one_transmit(now, &mut scratch);
+    assert!(
+      pumped.is_none(),
+      "an un-encodable query must not yield a transmit"
+    );
+    assert!(
+      s.queries.get(&h).map(|c| c.errored).unwrap_or(false),
+      "the query must be flagged errored after the encode failure"
+    );
+
+    // No standing deadline from the errored query (would otherwise busy-spin).
+    assert!(
+      s.poll_deadline().is_none(),
+      "an errored query must contribute no deadline"
+    );
+
+    // The one-shot terminal wake fires exactly once, then clears.
+    assert!(
+      s.take_query_terminal_wakes(),
+      "the terminal wake must be armed once on the errored transition"
+    );
+    assert!(
+      !s.take_query_terminal_wakes(),
+      "the terminal wake is one-shot — a second drain must report nothing"
+    );
+
+    // A subsequent pump skips the errored query entirely (no re-poll busy-spin).
+    assert!(
+      s.poll_one_transmit(now, &mut scratch).is_none(),
+      "an errored query must be skipped by later pumps, not re-polled"
+    );
+    assert!(
+      !s.take_query_terminal_wakes(),
+      "no further wake is armed once the query is already errored"
+    );
+  }
+}

--- a/mdns-compio/src/endpoint.rs
+++ b/mdns-compio/src/endpoint.rs
@@ -1,0 +1,406 @@
+//! Caller-side handle for an mDNS endpoint.
+
+use core::{
+  net::{IpAddr, Ipv4Addr, Ipv6Addr},
+  time::Duration,
+};
+use std::{rc::Rc, time::Instant};
+
+use futures::future::select_all;
+use mdns_proto::{
+  Name, QuerySpec, ServiceSpec,
+  wire::{ARecord, AaaaRecord, ResourceType},
+};
+use mdns_udp::{
+  MulticastOptionsV4, MulticastOptionsV6, try_bind_v4, try_bind_v6, try_join_v4, try_join_v6,
+};
+
+use crate::{
+  discovery::{Lookup, QueryParam, Resolver, ServiceEntry, Step, feed, fold, push_capped},
+  driver::{EndpointInner, run},
+  error::{RegisterError, ServerError, StartQueryError},
+  options::ServerOptions,
+  query::{Query, QueryEvent},
+  service::Service,
+  socket::Socket,
+};
+
+/// Handle to a running mDNS endpoint.
+///
+/// Cloneable; every clone shares the same underlying driver task. The driver
+/// task is spawned at [`Self::server`] time and exits when the last clone
+/// (and every derived [`Service`] / [`Query`] handle) is dropped — detected
+/// via `Rc::strong_count(&inner) == 1` inside the driver loop.
+#[derive(Clone)]
+pub struct Endpoint {
+  pub(crate) inner: Rc<EndpointInner>,
+}
+
+impl Endpoint {
+  /// Bind the multicast sockets configured in `opts` and spawn the driver
+  /// task on the current compio runtime.
+  pub async fn server(opts: ServerOptions) -> Result<Self, ServerError> {
+    if !opts.ipv4() && !opts.ipv6() {
+      return Err(ServerError::NoFamilyEnabled);
+    }
+
+    let interface_index = match opts.interface_index() {
+      Some(i) => i,
+      None => pick_default_interface_index(opts.ipv4(), opts.ipv6()).ok_or_else(|| {
+        ServerError::Io(std::io::Error::new(
+          std::io::ErrorKind::NotFound,
+          "no multicast-capable interface found",
+        ))
+      })?,
+    };
+
+    // Gracefully degrade — if the chosen interface lacks one of the
+    // requested families, bind only the family it can support rather than
+    // failing the entire endpoint.
+    let iface_has_v4 = match getifs::interface_by_index(interface_index) {
+      Ok(Some(i)) => matches!(i.ipv4_addrs(), Ok(ref a) if !a.is_empty()),
+      _ => false,
+    };
+    let iface_has_v6 = match getifs::interface_by_index(interface_index) {
+      Ok(Some(i)) => matches!(i.ipv6_addrs(), Ok(ref a) if !a.is_empty()),
+      _ => false,
+    };
+    let bind_v4 = opts.ipv4() && iface_has_v4;
+    let bind_v6 = opts.ipv6() && iface_has_v6;
+    if !bind_v4 && !bind_v6 {
+      return Err(ServerError::Io(std::io::Error::new(
+        std::io::ErrorKind::AddrNotAvailable,
+        "interface has no address in any requested family",
+      )));
+    }
+
+    let std_v4 = if bind_v4 {
+      let s = try_bind_v4(MulticastOptionsV4::new(interface_index)).map_err(ServerError::BindV4)?;
+      // Fail construction on a join error: a bound-but-unjoined socket can send
+      // but never receives multicast, making the endpoint silently
+      // non-functional. Mirrors the reactor's fatal-join setup.
+      try_join_v4(&s, interface_index).map_err(ServerError::JoinV4)?;
+      s.set_nonblocking(true).map_err(ServerError::Io)?;
+      Some(s)
+    } else {
+      None
+    };
+
+    let std_v6 = if bind_v6 {
+      let s = try_bind_v6(MulticastOptionsV6::new(interface_index)).map_err(ServerError::BindV6)?;
+      try_join_v6(&s, interface_index).map_err(ServerError::JoinV6)?;
+      s.set_nonblocking(true).map_err(ServerError::Io)?;
+      Some(s)
+    } else {
+      None
+    };
+
+    let sock_v4 = if let Some(s) = std_v4 {
+      Some(Rc::new(
+        Socket::from_std(s).await.map_err(ServerError::WrapSocket)?,
+      ))
+    } else {
+      None
+    };
+    let sock_v6 = if let Some(s) = std_v6 {
+      Some(Rc::new(
+        Socket::from_std(s).await.map_err(ServerError::WrapSocket)?,
+      ))
+    } else {
+      None
+    };
+
+    let inner = EndpointInner::new(
+      *opts.endpoint_config(),
+      opts.max_payload_size(),
+      opts.max_recv_packet_size(),
+    );
+
+    // Populate the §11 source-address fallback's local-subnet snapshot and
+    // pin the bound interface index under a brief borrow.
+    {
+      let mut st = inner.state.borrow_mut();
+      st.bound_interface = interface_index;
+      st.local_subnets = collect_local_subnets(interface_index);
+    }
+
+    let driver_fut = run(inner.clone(), sock_v4, sock_v6);
+    compio_runtime::spawn(driver_fut).detach();
+
+    Ok(Self { inner })
+  }
+
+  /// Register a new service.
+  ///
+  /// Returns a [`Service`] handle for receiving [`ServiceUpdate`] events;
+  /// dropping the handle implicitly unregisters the service. Drop encodes
+  /// the RFC 6762 §10.1 goodbye records and tears down the proto state
+  /// synchronously; the driver task then multicasts the queued TTL=0
+  /// datagrams a few times for loss resilience.
+  ///
+  /// [`ServiceUpdate`]: mdns_proto::ServiceUpdate
+  pub async fn register_service(&self, spec: ServiceSpec) -> Result<Service, RegisterError> {
+    let now = std::time::Instant::now();
+    let handle = {
+      let mut st = self.inner.state.borrow_mut();
+      st.register_service(spec, now)
+        .map_err(RegisterError::from)?
+    };
+    // Durable wake: a bare `notify()` can be lost across the driver's
+    // send-awaits, leaving newly-registered work unobserved (see
+    // `EndpointInner::dirty`). `mark_dirty` sets the level flag AND notifies.
+    self.inner.mark_dirty();
+    Ok(Service {
+      inner: self.inner.clone(),
+      handle,
+    })
+  }
+
+  /// Start a query against the endpoint.
+  ///
+  /// Returns a [`Query`] handle for receiving [`QueryEvent`]
+  /// events; dropping the handle implicitly cancels the query (the driver
+  /// removes the proto state machine on its next loop iteration).
+  pub async fn start_query(&self, spec: QuerySpec) -> Result<Query, StartQueryError> {
+    let now = std::time::Instant::now();
+    let handle = {
+      let mut st = self.inner.state.borrow_mut();
+      st.start_query(spec, now)
+        .map_err(|_| StartQueryError::StorageFull)?
+    };
+    // Durable wake (see `register_service` / `EndpointInner::dirty`): critical
+    // for a timeout-less `QuerySpec`, whose first transmit is the ONLY thing
+    // that would schedule a deadline — if this wake is lost and no deadline
+    // exists yet, the driver would otherwise park forever.
+    self.inner.mark_dirty();
+    Ok(Query {
+      inner: self.inner.clone(),
+      handle,
+      terminal_delivered: core::cell::Cell::new(false),
+    })
+  }
+
+  /// Browse for instances of a DNS-SD service type, resolving each into a
+  /// [`ServiceEntry`].  See [`Lookup`] and [`QueryParam`].
+  pub async fn browse(&self, param: QueryParam) -> Result<Lookup, StartQueryError> {
+    let resolve_timeout = param.resolve_timeout.unwrap_or(param.timeout);
+    // Size the PTR answer pool to the requested instance cap so a `max_entries`
+    // above the proto's default answer cap is actually reachable; without this
+    // surplus PTR answers would be evicted before the resolver could track
+    // them.
+    let ptr_spec = QuerySpec::new(param.service, ResourceType::Ptr)
+      .with_timeout(param.timeout)
+      .with_unicast_response(param.unicast_response)
+      .with_max_answers(param.max_entries);
+    let ptr_query = self.start_query(ptr_spec).await?;
+    Ok(Lookup {
+      endpoint: self.clone(),
+      queries: vec![(ptr_query, Step::Ptr)],
+      resolver: Resolver::new(param.max_entries),
+      resolve_timeout,
+      unicast: param.unicast_response,
+      finished: false,
+    })
+  }
+
+  /// Convenience for [`Self::browse`] with default parameters and the given
+  /// browse timeout.
+  pub async fn lookup(&self, service: Name, timeout: Duration) -> Result<Lookup, StartQueryError> {
+    self
+      .browse(QueryParam::new(service).with_timeout(timeout))
+      .await
+  }
+
+  /// Resolve a host name to its addresses via mDNS A / AAAA queries (RFC 6762),
+  /// without the DNS-SD browse/resolve chain.
+  ///
+  /// Issues both queries and collects every advertised address for the
+  /// `timeout` window (the answer window for multicast responses), returning
+  /// them IPv4 first then IPv6, deduplicated and capped per family.  The
+  /// result is empty if nothing answers.  Unlike [`Self::resolve_instance`]
+  /// this does not require — or interpret — DNS-SD records; it is the
+  /// multicast analogue of resolving a hostname.
+  pub async fn resolve_host(
+    &self,
+    host: Name,
+    timeout: Duration,
+  ) -> Result<Vec<IpAddr>, StartQueryError> {
+    // One deadline shared across both queries: the call stays bounded by
+    // `timeout` even if launching the second sub-query takes some of it.
+    // `checked_add` so `Duration::MAX` cannot panic the way `Instant + Duration`
+    // would.
+    let deadline = Instant::now().checked_add(timeout);
+    let remaining = || deadline.map_or(timeout, |d| d.saturating_duration_since(Instant::now()));
+    let host_key = fold(&host);
+    let qa = self
+      .start_query(QuerySpec::new(host.clone(), ResourceType::A).with_timeout(remaining()))
+      .await?;
+    let qaaaa = self
+      .start_query(QuerySpec::new(host, ResourceType::Aaaa).with_timeout(remaining()))
+      .await?;
+    let mut ipv4: Vec<Ipv4Addr> = Vec::new();
+    let mut ipv6: Vec<Ipv6Addr> = Vec::new();
+    let mut queries: Vec<(Query, Step)> = vec![
+      (qa, Step::A(host_key.clone())),
+      (qaaaa, Step::Aaaa(host_key)),
+    ];
+    while !queries.is_empty() {
+      let (result, idx) = {
+        let futs: Vec<_> = queries.iter().map(|(q, _)| Box::pin(q.next())).collect();
+        let (result, idx, _remaining) = select_all(futs).await;
+        (result, idx)
+      };
+      match result {
+        Some(QueryEvent::Answer(ans)) => match &queries[idx].1 {
+          Step::A(_) if ans.rtype() == ResourceType::A => {
+            if let Ok(r) = ARecord::try_from_rdata(ans.rdata_slice()) {
+              push_capped(&mut ipv4, r.addr());
+            }
+          }
+          Step::Aaaa(_) if ans.rtype() == ResourceType::Aaaa => {
+            if let Ok(r) = AaaaRecord::try_from_rdata(ans.rdata_slice()) {
+              push_capped(&mut ipv6, r.addr());
+            }
+          }
+          _ => {}
+        },
+        Some(QueryEvent::Terminal(_)) | None => {
+          queries.swap_remove(idx);
+        }
+      }
+    }
+    Ok(
+      ipv4
+        .into_iter()
+        .map(IpAddr::V4)
+        .chain(ipv6.into_iter().map(IpAddr::V6))
+        .collect(),
+    )
+  }
+
+  /// Resolve a *known* DNS-SD service instance directly into a
+  /// [`ServiceEntry`], skipping the PTR browse step (e.g.
+  /// `Name::try_from_str("Office._ipp._tcp.local.")`).
+  ///
+  /// Issues SRV + TXT for the instance and A / AAAA for the SRV target host,
+  /// and returns the first complete resolution — host + port, TXT, and at
+  /// least one address — or `None` if it does not complete within `timeout`.
+  /// Use [`Self::browse`] instead when the instance names are not known in
+  /// advance.
+  pub async fn resolve_instance(
+    &self,
+    instance: Name,
+    timeout: Duration,
+  ) -> Result<Option<ServiceEntry>, StartQueryError> {
+    // Shared deadline so an SRV arriving late cannot grant the A/AAAA
+    // follow-ups a second full `timeout` window.
+    let deadline = Instant::now().checked_add(timeout);
+    let remaining = || deadline.map_or(timeout, |d| d.saturating_duration_since(Instant::now()));
+    let mut resolver = Resolver::new(1);
+    let mut queries: Vec<(Query, Step)> = Vec::new();
+    for start in resolver.on_ptr(instance) {
+      let qtype = start.qtype();
+      let q = self
+        .start_query(QuerySpec::new(start.name, qtype).with_timeout(remaining()))
+        .await?;
+      queries.push((q, start.step));
+    }
+    loop {
+      if let Some(e) = resolver.take_ready() {
+        return Ok(Some(e));
+      }
+      if queries.is_empty() {
+        return Ok(None);
+      }
+      let (result, idx) = {
+        let futs: Vec<_> = queries.iter().map(|(q, _)| Box::pin(q.next())).collect();
+        let (result, idx, _remaining) = select_all(futs).await;
+        (result, idx)
+      };
+      match result {
+        Some(QueryEvent::Answer(_)) => {
+          let step = queries[idx].1.clone();
+          let event = result.expect("matched Some above");
+          for start in feed(&mut resolver, step, event) {
+            let qtype = start.qtype();
+            let q = self
+              .start_query(QuerySpec::new(start.name, qtype).with_timeout(remaining()))
+              .await?;
+            queries.push((q, start.step));
+          }
+        }
+        Some(QueryEvent::Terminal(_)) | None => {
+          queries.swap_remove(idx);
+        }
+      }
+    }
+  }
+}
+
+/// Wake the driver when an `Endpoint` clone is dropped so it can promptly
+/// observe `Rc::strong_count(&inner) == 1` and exit (per the T9 exit-condition
+/// contract). Without this notify, the driver would only notice the dropped
+/// handle the next time it woke for a recv / timer event.
+impl Drop for Endpoint {
+  fn drop(&mut self) {
+    self.inner.notify.notify();
+  }
+}
+
+/// Snapshot the local IPv4 / IPv6 subnets owned by `iface_index`. Used by
+/// the §11 on-link source-address fallback when the kernel did not deliver
+/// an IPv4 TTL / IPv6 hop-limit cmsg.
+fn collect_local_subnets(iface_index: u32) -> Vec<(core::net::IpAddr, u8)> {
+  let mut out: Vec<(core::net::IpAddr, u8)> = Vec::new();
+  if iface_index == 0 {
+    return out;
+  }
+  if let Ok(Some(i)) = getifs::interface_by_index(iface_index) {
+    if let Ok(v4s) = i.ipv4_addrs() {
+      for n in v4s.iter() {
+        out.push((core::net::IpAddr::V4(n.addr()), n.prefix_len()));
+      }
+    }
+    if let Ok(v6s) = i.ipv6_addrs() {
+      for n in v6s.iter() {
+        out.push((core::net::IpAddr::V6(n.addr()), n.prefix_len()));
+      }
+    }
+  }
+  out
+}
+
+/// Pick a default interface index when the caller didn't pin one. Mirrors
+/// the algorithm in `mdns-reactor::endpoint::pick_default_interface_index`:
+/// prefer a non-loopback, multicast-up interface that satisfies every
+/// requested family; fall back through looser predicates ending at the
+/// loopback interface.
+fn pick_default_interface_index(want_v4: bool, want_v6: bool) -> Option<u32> {
+  let ifs = getifs::interfaces().ok()?;
+  let has_v4 = |i: &getifs::Interface| matches!(i.ipv4_addrs(), Ok(ref v) if !v.is_empty());
+  let has_v6 = |i: &getifs::Interface| matches!(i.ipv6_addrs(), Ok(ref v) if !v.is_empty());
+  let multicast_up_non_loopback = |i: &getifs::Interface| -> bool {
+    let f = i.flags();
+    f.contains(getifs::Flags::UP)
+      && f.contains(getifs::Flags::MULTICAST)
+      && !f.contains(getifs::Flags::LOOPBACK)
+      && i.index() != 0
+  };
+  let loopback_up = |i: &getifs::Interface| -> bool {
+    i.flags().contains(getifs::Flags::LOOPBACK) && i.flags().contains(getifs::Flags::UP)
+  };
+  let strict =
+    |i: &&getifs::Interface| -> bool { (!want_v4 || has_v4(i)) && (!want_v6 || has_v6(i)) };
+  let loose = |i: &&getifs::Interface| -> bool { (want_v4 && has_v4(i)) || (want_v6 && has_v6(i)) };
+  ifs
+    .iter()
+    .find(|i| multicast_up_non_loopback(i) && strict(i))
+    .or_else(|| {
+      ifs
+        .iter()
+        .find(|i| multicast_up_non_loopback(i) && loose(i))
+    })
+    .or_else(|| ifs.iter().find(|i| loopback_up(i) && strict(i)))
+    .or_else(|| ifs.iter().find(|i| loopback_up(i) && loose(i)))
+    .map(|i| i.index())
+}

--- a/mdns-compio/src/error.rs
+++ b/mdns-compio/src/error.rs
@@ -1,0 +1,109 @@
+//! Public error types surfaced by the async API.
+
+use mdns_proto::{Name, error::RegisterServiceError as ProtoRegisterError};
+
+/// Errors raised while constructing or running an [`Endpoint`](crate::Endpoint).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ServerError {
+  /// At least one of IPv4 / IPv6 must be enabled in
+  /// [`ServerOptions`](crate::ServerOptions).
+  #[error("ServerOptions has neither IPv4 nor IPv6 enabled")]
+  NoFamilyEnabled,
+
+  /// Binding the IPv4 multicast socket failed.
+  #[error("bind v4: {0}")]
+  BindV4(mdns_udp::BindError),
+
+  /// Binding the IPv6 multicast socket failed.
+  #[error("bind v6: {0}")]
+  BindV6(mdns_udp::BindError),
+
+  /// Joining the IPv4 mDNS multicast group failed. The socket bound but never
+  /// joined `224.0.0.251`, so it could send but not receive multicast — a
+  /// silent failure if ignored, hence surfaced at construction.
+  #[error("join v4: {0}")]
+  JoinV4(mdns_udp::JoinError),
+
+  /// Joining the IPv6 mDNS multicast group failed (`ff02::fb`). See
+  /// [`Self::JoinV4`].
+  #[error("join v6: {0}")]
+  JoinV6(mdns_udp::JoinError),
+
+  /// Wrapping the bound socket as an async UDP socket failed.
+  #[error("wrap socket: {0}")]
+  WrapSocket(std::io::Error),
+
+  /// I/O error during endpoint setup (e.g. setting non-blocking mode).
+  #[error(transparent)]
+  Io(#[from] std::io::Error),
+}
+
+/// Errors raised by
+/// [`Endpoint::register_service`](crate::Endpoint::register_service).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RegisterError {
+  /// A service with the same instance name is already registered.
+  #[error("name already registered: {0}")]
+  NameAlreadyRegistered(Name),
+
+  /// The proto service pool is full.
+  #[error("service pool is full")]
+  StorageFull,
+
+  /// The driver task is no longer running.
+  #[error("endpoint driver is gone")]
+  DriverGone,
+
+  /// A future, currently-unknown variant of
+  /// [`ProtoRegisterError`](mdns_proto::error::RegisterServiceError) that
+  /// the conversion arm did not recognise. The wrapped string is the proto
+  /// error's `Display` output so callers can still log it meaningfully.
+  ///
+  /// Reachable only if `mdns-proto` grows a new `RegisterServiceError`
+  /// variant before this crate is updated to map it explicitly.
+  #[error("unexpected proto register error: {0}")]
+  Other(String),
+}
+
+impl From<ProtoRegisterError> for RegisterError {
+  fn from(e: ProtoRegisterError) -> Self {
+    // `ProtoRegisterError` is `#[non_exhaustive]`, so we MUST keep a
+    // catch-all. We enumerate every variant that exists today by name so
+    // adding a new proto variant trips a `// future:` review here rather
+    // than silently mis-mapping. Unknown future variants surface as
+    // [`Self::Other`] — preserving their `Display` — instead of being
+    // squashed into [`Self::StorageFull`] (which would lie about the
+    // failure mode).
+    match e {
+      ProtoRegisterError::NameAlreadyRegistered(n) => Self::NameAlreadyRegistered(n),
+      ProtoRegisterError::StorageFull(_) => Self::StorageFull,
+      // future: map any new ProtoRegisterError variant to a dedicated
+      // RegisterError arm here instead of falling through to `Other`.
+      other => Self::Other(other.to_string()),
+    }
+  }
+}
+
+/// Errors raised by [`Endpoint::start_query`](crate::Endpoint::start_query).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartQueryError {
+  /// The proto query pool is full.
+  #[error("query pool is full")]
+  StorageFull,
+
+  /// The driver task is no longer running.
+  #[error("endpoint driver is gone")]
+  DriverGone,
+}
+
+/// Errors raised by query cancellation and service unregistration.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CancelError {
+  /// The driver task is no longer running.
+  #[error("endpoint driver is gone")]
+  DriverGone,
+}

--- a/mdns-compio/src/lib.rs
+++ b/mdns-compio/src/lib.rs
@@ -1,0 +1,30 @@
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_op_in_unsafe_fn)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
+
+pub(crate) mod driver;
+pub(crate) mod onlink;
+pub(crate) mod selfsend;
+pub(crate) mod socket;
+
+pub mod discovery;
+pub mod endpoint;
+pub mod error;
+pub mod options;
+pub mod query;
+pub mod service;
+
+pub use discovery::{DEFAULT_MAX_ENTRIES, Lookup, QueryParam, ServiceEntry};
+pub use endpoint::Endpoint;
+pub use error::{CancelError, RegisterError, ServerError, StartQueryError};
+pub use options::ServerOptions;
+pub use query::{Query, QueryEvent};
+pub use service::Service;
+
+// Re-export the `mdns-proto` types the public surface uses, mirroring
+// `mdns-reactor`.
+pub use mdns_proto::{
+  CollectedAnswer, Name, QueryHandle, QuerySpec, QueryUpdate, ServiceHandle, ServiceRecords,
+  ServiceSpec, ServiceUpdate, wire,
+};

--- a/mdns-compio/src/onlink.rs
+++ b/mdns-compio/src/onlink.rs
@@ -1,0 +1,150 @@
+//! RFC 6762 §11 on-link checks.
+
+use core::net::IpAddr;
+
+/// TTL / IPv6 Hop Limit is exactly 255 (anything less crossed a router).
+/// When no cmsg was delivered we conservatively treat the datagram as on-link
+/// and let the source-address fallback ([`src_on_local_link`]) decide.
+#[inline]
+pub(crate) fn is_on_link(hop_limit: Option<u8>) -> bool {
+  hop_limit.is_none_or(|h| h == 255)
+}
+
+/// Source-address fallback for the §11 on-link gate, used when the kernel did
+/// not deliver an IPv4 TTL / IPv6 hop-limit cmsg. Loopback is always on-link,
+/// link-local sources must match the bound interface (or arrive with no
+/// `recv_iface` hint), and globally-routable sources are accepted only if
+/// they fall inside one of the cached `local_subnets`.
+///
+/// Fail-closed for global sources: a routable source with no matching subnet —
+/// including the case where subnet enumeration yielded nothing — is treated as
+/// off-link and dropped, per §11. We never admit a global source on no
+/// evidence that it originated on the local link.
+pub(crate) fn src_on_local_link(
+  local_subnets: &[(IpAddr, u8)],
+  bound_iface: u32,
+  recv_iface: u32,
+  src: IpAddr,
+) -> bool {
+  let (is_loopback, is_link_local) = match src {
+    IpAddr::V4(v4) => (v4.is_loopback(), v4.is_link_local()),
+    IpAddr::V6(v6) => (v6.is_loopback(), (v6.segments()[0] & 0xffc0) == 0xfe80),
+  };
+  if is_loopback {
+    return true;
+  }
+  if is_link_local {
+    return recv_iface == 0 || recv_iface == bound_iface;
+  }
+  // Global source: admit only with positive on-link evidence. An empty
+  // `local_subnets` makes `any` return `false` (fail-closed) — see §11.
+  local_subnets
+    .iter()
+    .any(|&(net, p)| addr_in_subnet(net, p, src))
+}
+
+/// `addr ∈ net/prefix` with a bit-mask compare. Mixed v4/v6 pairs are always
+/// `false`. A `prefix` of zero matches every address of the matching family.
+pub(crate) fn addr_in_subnet(net: IpAddr, prefix: u8, addr: IpAddr) -> bool {
+  match (net, addr) {
+    (IpAddr::V4(n), IpAddr::V4(a)) => {
+      let p = prefix.min(32);
+      if p == 0 {
+        return true;
+      }
+      let mask: u32 = u32::MAX.checked_shl(32 - u32::from(p)).unwrap_or(0);
+      (u32::from(n) & mask) == (u32::from(a) & mask)
+    }
+    (IpAddr::V6(n), IpAddr::V6(a)) => {
+      let p = prefix.min(128);
+      if p == 0 {
+        return true;
+      }
+      let mask: u128 = u128::MAX.checked_shl(128 - u32::from(p)).unwrap_or(0);
+      (u128::from(n) & mask) == (u128::from(a) & mask)
+    }
+    _ => false,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use core::net::{IpAddr, Ipv4Addr};
+
+  use super::*;
+
+  #[test]
+  fn ttl_255_is_on_link() {
+    assert!(is_on_link(Some(255)));
+  }
+
+  #[test]
+  fn ttl_less_than_255_is_off_link() {
+    assert!(!is_on_link(Some(254)));
+  }
+
+  #[test]
+  fn missing_ttl_is_on_link() {
+    assert!(is_on_link(None));
+  }
+
+  #[test]
+  fn addr_in_loopback_8() {
+    let net = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0));
+    assert!(addr_in_subnet(
+      net,
+      8,
+      IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+    ));
+    assert!(!addr_in_subnet(
+      net,
+      8,
+      IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
+    ));
+  }
+
+  #[test]
+  fn link_local_must_match_iface() {
+    let subnets: &[(IpAddr, u8)] = &[];
+    let src = IpAddr::V4(Ipv4Addr::new(169, 254, 1, 2));
+    assert!(src_on_local_link(subnets, 5, 5, src));
+    assert!(!src_on_local_link(subnets, 5, 6, src));
+    assert!(src_on_local_link(subnets, 5, 0, src));
+  }
+
+  #[test]
+  fn loopback_is_always_on_link() {
+    let subnets: &[(IpAddr, u8)] = &[];
+    let src = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    assert!(src_on_local_link(subnets, 5, 5, src));
+    assert!(src_on_local_link(subnets, 5, 99, src));
+  }
+
+  #[test]
+  fn global_source_dropped_without_subnet_evidence() {
+    // §11 fail-closed: a routable source with no enumerated subnets has no
+    // on-link evidence and must be dropped (loopback/link-local early-return
+    // before this point, so this exercises the global path on an empty list).
+    let src = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+    assert!(!src_on_local_link(&[], 5, 5, src));
+  }
+
+  #[test]
+  fn global_source_admitted_when_in_subnet() {
+    // A global source inside a cached local subnet is on-link; one outside
+    // every cached subnet is dropped.
+    let subnets: &[(IpAddr, u8)] = &[(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8)];
+    assert!(src_on_local_link(
+      subnets,
+      5,
+      5,
+      IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))
+    ));
+    assert!(!src_on_local_link(
+      subnets,
+      5,
+      5,
+      IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
+    ));
+  }
+}

--- a/mdns-compio/src/options.rs
+++ b/mdns-compio/src/options.rs
@@ -1,0 +1,134 @@
+//! Caller-facing construction options for [`Endpoint`](crate::Endpoint).
+//!
+//! Mirrors the public shape of `mdns-reactor::ServerOptions` so callers can
+//! move between the two crates without re-learning the surface.
+
+use mdns_proto::EndpointConfig;
+
+/// Build-time configuration for an mDNS [`Endpoint`](crate::Endpoint).
+///
+/// The defaults bind on **one** interface for both IPv4 and IPv6: the first
+/// up + multicast-capable, non-loopback interface reported by
+/// [`getifs::interfaces`] that has a usable address for each enabled family,
+/// falling back to the loopback interface if no other is eligible. Use
+/// [`Self::with_interface_index`] to pin a specific interface.
+#[derive(Debug, Clone)]
+pub struct ServerOptions {
+  pub(crate) ipv4: bool,
+  pub(crate) ipv6: bool,
+  pub(crate) interface_index: Option<u32>,
+  pub(crate) max_payload_size: usize,
+  pub(crate) max_recv_packet_size: usize,
+  pub(crate) endpoint_config: EndpointConfig,
+}
+
+impl Default for ServerOptions {
+  #[inline]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl ServerOptions {
+  /// Build a new options bundle with defaults.
+  #[inline]
+  pub fn new() -> Self {
+    Self {
+      ipv4: true,
+      ipv6: true,
+      interface_index: None,
+      max_payload_size: 1500,
+      max_recv_packet_size: 9000,
+      endpoint_config: EndpointConfig::new(),
+    }
+  }
+
+  /// Whether IPv4 is enabled.
+  #[inline]
+  pub const fn ipv4(&self) -> bool {
+    self.ipv4
+  }
+
+  /// Whether IPv6 is enabled.
+  #[inline]
+  pub const fn ipv6(&self) -> bool {
+    self.ipv6
+  }
+
+  /// The pinned interface index, if any.
+  #[inline]
+  pub const fn interface_index(&self) -> Option<u32> {
+    self.interface_index
+  }
+
+  /// Maximum outgoing-packet buffer size. RFC 6762 §17 recommends staying
+  /// within the path MTU on send (~1500 bytes for Ethernet).
+  #[inline]
+  pub const fn max_payload_size(&self) -> usize {
+    self.max_payload_size
+  }
+
+  /// Maximum size of an inbound mDNS datagram that we will fully receive
+  /// without truncation. RFC 6762 §17 says implementations MUST be prepared
+  /// to receive messages up to 9000 bytes.
+  #[inline]
+  pub const fn max_recv_packet_size(&self) -> usize {
+    self.max_recv_packet_size
+  }
+
+  /// The proto-layer [`EndpointConfig`].
+  #[inline]
+  pub const fn endpoint_config(&self) -> &EndpointConfig {
+    &self.endpoint_config
+  }
+
+  /// Enable or disable IPv4. At least one of v4/v6 must remain enabled.
+  #[inline]
+  #[must_use]
+  pub const fn with_ipv4(mut self, enable: bool) -> Self {
+    self.ipv4 = enable;
+    self
+  }
+
+  /// Enable or disable IPv6.
+  #[inline]
+  #[must_use]
+  pub const fn with_ipv6(mut self, enable: bool) -> Self {
+    self.ipv6 = enable;
+    self
+  }
+
+  /// Pin the listener to a specific interface (by OS index). When `None`
+  /// (the default), the first multicast-capable, non-loopback interface is
+  /// picked.
+  #[inline]
+  #[must_use]
+  pub const fn with_interface_index(mut self, idx: Option<u32>) -> Self {
+    self.interface_index = idx;
+    self
+  }
+
+  /// Override the maximum outgoing-packet buffer size.
+  #[inline]
+  #[must_use]
+  pub const fn with_max_payload_size(mut self, size: usize) -> Self {
+    self.max_payload_size = size;
+    self
+  }
+
+  /// Override the inbound receive buffer size.
+  #[inline]
+  #[must_use]
+  pub const fn with_max_recv_packet_size(mut self, size: usize) -> Self {
+    self.max_recv_packet_size = size;
+    self
+  }
+
+  /// Override the proto-layer [`EndpointConfig`].
+  #[inline]
+  #[must_use]
+  pub fn with_endpoint_config(mut self, cfg: EndpointConfig) -> Self {
+    self.endpoint_config = cfg;
+    self
+  }
+}

--- a/mdns-compio/src/query.rs
+++ b/mdns-compio/src/query.rs
@@ -1,0 +1,230 @@
+//! `Query` handle returned by [`Endpoint::start_query`].
+//!
+//! Holds an [`Rc<EndpointInner>`] + the proto-layer [`QueryHandle`]. The driver
+//! task owns the proto `Query` state machine inside `State.queries`; this handle
+//! reads collected answers and terminal updates directly off the proto state
+//! under a brief borrow, then parks on the shared driver notifier when nothing
+//! is ready.
+//!
+//! Dropping a [`Query`] flags the registration as cancelled and removes it from
+//! the proto endpoint, then wakes the driver so any pending transmits queued for
+//! the handle stop firing.
+//!
+//! [`Endpoint::start_query`]: crate::Endpoint::start_query
+
+use core::cell::Cell;
+use std::rc::Rc;
+
+use mdns_proto::{CollectedAnswer, QueryHandle, QueryUpdate};
+
+use crate::driver::EndpointInner;
+
+/// One event surfaced by [`Query::next`]: either an answer collected by the
+/// underlying state machine, or the terminal update signalling the query has
+/// ended (timeout / done).  Answers are delivered in monotonically-increasing
+/// `seq()` order; the terminal is always the last event surfaced.
+#[derive(Debug, Clone)]
+pub enum QueryEvent {
+  /// A new answer collected by the underlying state machine.
+  Answer(CollectedAnswer),
+  /// The query reached a terminal state. Always the last event delivered.
+  Terminal(QueryUpdate),
+}
+
+/// Handle to an in-flight query.
+///
+/// Dropping the handle implicitly cancels the query: the driver task removes
+/// the proto state machine on its next loop iteration so no further transmits
+/// fire against it.
+pub struct Query {
+  pub(crate) inner: Rc<EndpointInner>,
+  pub(crate) handle: QueryHandle,
+  /// Latches once the terminal `QueryEvent` has been surfaced via
+  /// [`Self::next`], so subsequent calls report end-of-stream rather than
+  /// re-polling the proto layer.  `Cell<bool>` interior mutability is sound
+  /// because the type is `!Send` (held via [`Rc`]) and [`Self::next`] is the
+  /// single consumer.
+  pub(crate) terminal_delivered: Cell<bool>,
+}
+
+impl Query {
+  /// The underlying proto-layer [`QueryHandle`] for this query.
+  #[inline]
+  pub const fn handle(&self) -> QueryHandle {
+    self.handle
+  }
+
+  /// Wait for the next answer or terminal.  Returns `None` once the terminal
+  /// has been delivered (single-consumer; subsequent calls report
+  /// end-of-stream) or the driver has dropped the query entry.
+  ///
+  /// Borrow discipline: every interaction with `inner.state` is confined to a
+  /// short synchronous scope; the only `.await` (`notify.listen()`) runs after
+  /// the borrow is dropped at the closing `}` of the scope.
+  pub async fn next(&self) -> Option<QueryEvent> {
+    loop {
+      if self.terminal_delivered.get() {
+        return None;
+      }
+      // Brief synchronous borrow — read one event off the proto state, else
+      // fall through to park.  The borrow is dropped at the closing `}` of
+      // this block, well before any `.await`.
+      {
+        let mut st = self.inner.state.borrow_mut();
+        // The driver removes our entry on cancellation / endpoint teardown.
+        let ctx = st.queries.get(&self.handle)?;
+        let last = ctx.last_seq;
+        let cancelled = ctx.cancelled;
+        // The driver flags a query `errored` when its question can't be encoded
+        // into `max_payload` (see `QueryCtx::errored`): it has no standing
+        // deadline and can never make progress, so surface end-of-stream rather
+        // than park forever. We still drain any already-collected answers below
+        // first, then fall through to the terminal.
+        let errored = ctx.errored;
+        // Surface the next undelivered answer in `seq` order (see
+        // [`next_answer_by_seq`] for why min-by-seq, not first-iterated),
+        // advancing `last_seq` past it so we don't re-deliver on the next pass.
+        let next_answer = next_answer_by_seq(st.endpoint.collected_answers(self.handle), last);
+        if let Some(a) = next_answer {
+          let new_last = a.seq().saturating_add(1);
+          if let Some(ctx) = st.queries.get_mut(&self.handle) {
+            ctx.last_seq = new_last;
+          }
+          return Some(QueryEvent::Answer(a));
+        }
+        // No pending answer; the proto layer surfaces the terminal once via
+        // `poll_query`, then None forever.
+        if let Some(t) = st.endpoint.poll_query(self.handle) {
+          self.terminal_delivered.set(true);
+          return Some(QueryEvent::Terminal(t));
+        }
+        // Driver flagged us cancelled (drop path) or errored (un-encodable
+        // question) and no answer/terminal was pending — surface end-of-stream.
+        if cancelled || errored {
+          self.terminal_delivered.set(true);
+          return None;
+        }
+      }
+      // Nothing buffered: park on the driver's notify. The borrow above is
+      // already dropped, so this await never holds a RefCell borrow.
+      self.inner.notify.listen().await;
+    }
+  }
+}
+
+/// Pick the next answer to surface from a query's collected-answer snapshot:
+/// the one with the SMALLEST `seq` that is `>= last` (the smallest not-yet-
+/// delivered sequence number), cloned out.
+///
+/// Selecting the minimum — rather than the first item the iterator yields — is
+/// load-bearing. `collected_answers` is proto's BOUNDED snapshot backed by a
+/// `slab::Slab`, so it iterates in SLAB-KEY order, not `seq` order: once
+/// `max_answers` is reached the proto FIFO-evicts the lowest-`seq` entry and the
+/// freed low slab key is reused by the next insert, so a higher-`seq` answer can
+/// sit at a lower key ahead of older retained lower-`seq` answers. Taking the
+/// first item with `seq >= last` (the previous behaviour) would deliver that
+/// higher-`seq` answer, jump `last_seq` past it, and PERMANENTLY skip the still-
+/// retained lower-`seq` answers — so a peer flooding more than `max_answers`
+/// distinct records before the app drains could make browse/lookup/resolve
+/// silently miss valid records. Min-by-`seq` keeps delivery strictly ordered
+/// regardless of slab layout.
+fn next_answer_by_seq<'a>(
+  answers: impl Iterator<Item = &'a CollectedAnswer>,
+  last: u64,
+) -> Option<CollectedAnswer> {
+  answers
+    .filter(|a| a.seq() >= last)
+    .min_by_key(|a| a.seq())
+    .cloned()
+}
+
+impl Drop for Query {
+  fn drop(&mut self) {
+    // Flag cancellation, then remove the proto-layer query immediately so any
+    // pending transmits stop firing.  Wake the driver so it observes the
+    // change on its next loop iteration.
+    {
+      let mut st = self.inner.state.borrow_mut();
+      st.flag_query_cancelled(self.handle);
+      let _ = st.endpoint.cancel_query(self.handle);
+      st.queries.remove(&self.handle);
+    }
+    // Durable wake (see `EndpointInner::dirty`): removing the query may free the
+    // last handle, and the driver must re-settle to observe the change even if a
+    // bare notify would be lost across its send-awaits.
+    self.inner.mark_dirty();
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use mdns_proto::{
+    CollectedAnswer,
+    wire::{ResourceClass, ResourceType},
+  };
+
+  use super::next_answer_by_seq;
+
+  /// A distinct synthetic answer carrying `seq` (encoded into rdata so answers
+  /// don't coalesce). Mirrors `mdns-reactor`'s test answer helper.
+  fn answer(seq: u64) -> CollectedAnswer {
+    CollectedAnswer::from_parts(
+      ResourceType::Ptr,
+      ResourceClass::In,
+      seq.to_be_bytes().to_vec(),
+      seq,
+    )
+  }
+
+  /// The selection must follow `seq`, NOT the iterator's (slab-key) order. This
+  /// reproduces the post-eviction slab-key reuse layout: a higher-seq answer
+  /// occupies a lower slab key and is therefore yielded FIRST by the snapshot
+  /// iterator, ahead of an older retained lower-seq answer. `next_answer_by_seq`
+  /// must still pick the lower seq.
+  #[test]
+  fn picks_min_seq_not_first_iterated() {
+    // Iterator order [5, 2]: seq 5 sits at the reused low slab key, seq 2 after.
+    let snapshot = [answer(5), answer(2)];
+    let picked = next_answer_by_seq(snapshot.iter(), 0).expect("an answer is pending");
+    assert_eq!(
+      picked.seq(),
+      2,
+      "must surface the minimum seq >= last, not the first iterated (5)"
+    );
+  }
+
+  /// Walking `last` forward across an out-of-order snapshot must deliver EVERY
+  /// retained answer exactly once, in strict seq order — the old first-match
+  /// logic would jump `last` past the lower-seq entries and strand them.
+  #[test]
+  fn walks_every_retained_answer_in_seq_order() {
+    // Out-of-slab-order snapshot with a FIFO gap (seq 0/1 were evicted): the
+    // lowest retained seq is 2. Keys deliberately scrambled.
+    let snapshot = [answer(4), answer(2), answer(6), answer(3), answer(5)];
+    let mut last = 0u64;
+    let mut delivered = Vec::new();
+    while let Some(a) = next_answer_by_seq(snapshot.iter(), last) {
+      delivered.push(a.seq());
+      last = a.seq().saturating_add(1);
+    }
+    assert_eq!(
+      delivered,
+      vec![2, 3, 4, 5, 6],
+      "every retained answer delivered once, in seq order, none skipped"
+    );
+  }
+
+  /// Nothing newer than `last` → no answer (terminal/park path).
+  #[test]
+  fn none_when_all_already_delivered() {
+    let snapshot = [answer(2), answer(3)];
+    assert!(
+      next_answer_by_seq(snapshot.iter(), 4).is_none(),
+      "no answer with seq >= 4 is present"
+    );
+    assert!(
+      next_answer_by_seq([].iter(), 0).is_none(),
+      "empty snapshot yields nothing"
+    );
+  }
+}

--- a/mdns-compio/src/selfsend.rs
+++ b/mdns-compio/src/selfsend.rs
@@ -1,0 +1,201 @@
+//! FNV-1a self-send hash tracker (Ordered + Degraded match modes).
+//!
+//! Used by the driver to consume the loopback echo of multicast datagrams
+//! the endpoint just sent — so the proto state machine doesn't ingest its
+//! own announce/probe traffic as if it were an external peer.
+
+use std::time::{Duration, SystemTime};
+
+/// Self-send tracker storage: `(content_hash, body_len, send_wall_time)` for
+/// every datagram the endpoint recently transmitted.  Keying on
+/// `(hash, length)` rather than the FNV-1a hash alone means a hash collision
+/// cannot, by itself, consume a self-send credit or misclassify a peer
+/// datagram as our own loopback echo.
+pub(crate) type SelfSends = Vec<(u64, u32, SystemTime)>;
+
+/// Maximum age of a tracker entry before it is swept on the next
+/// `record_self_send` call.
+pub(crate) const SELF_SEND_TTL: Duration = Duration::from_secs(2);
+
+/// Soft cap on the self-send tracker.  Mirrors `mdns-reactor::driver`'s
+/// constant; an oversized tracker silently drops new records rather than
+/// growing without bound on a misbehaving loopback path.
+pub(crate) const MAX_SELF_SEND_ENTRIES: usize = 65536;
+
+/// Match mode for [`take_self_send`].
+///
+/// - `Ordered`: the reference timestamp may sit up to 1 ms *before* the
+///   recorded send time — accounts for kernel timestamping that captures the
+///   rx clock at a slightly earlier reading than the post-send wall clock.
+/// - `Degraded`: no pre-send slack; the reference must be at or after the
+///   recorded send time.  Used when the kernel did not deliver a rx
+///   timestamp and the driver falls back to `SystemTime::now()`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum MatchMode {
+  Ordered,
+  Degraded,
+}
+
+/// Record a freshly transmitted datagram in the self-send tracker.  Sweeps
+/// any entries past [`SELF_SEND_TTL`] first, then pushes a new entry iff the
+/// tracker is below [`MAX_SELF_SEND_ENTRIES`].  Each entry keys on both the
+/// FNV-1a hash and the body length, so a hash collision alone can't consume a
+/// credit.
+pub(crate) fn record_self_send(tracker: &mut SelfSends, body: &[u8], sent: SystemTime) {
+  tracker.retain(|(_, _, t)| {
+    sent
+      .duration_since(*t)
+      .is_ok_and(|age| age <= SELF_SEND_TTL)
+  });
+  if tracker.len() < MAX_SELF_SEND_ENTRIES {
+    tracker.push((fnv1a(body), body.len() as u32, sent));
+  }
+}
+
+/// Consume one tracker entry whose FNV-1a hash *and* length of `body` match
+/// and whose recorded send time falls inside the match window for `mode`.
+/// Returns `true` when an entry was consumed (i.e. the datagram is our own
+/// loopback echo and the caller should pass `caller_is_self = true` into
+/// `endpoint.handle`).  Requiring the body length to match as well as the hash
+/// means a lossy FNV-1a collision alone cannot misclassify a peer datagram as
+/// self.
+pub(crate) fn take_self_send(
+  tracker: &mut SelfSends,
+  body: &[u8],
+  reference: SystemTime,
+  mode: MatchMode,
+) -> bool {
+  let needle = fnv1a(body);
+  let needle_len = body.len() as u32;
+  if let Some(pos) = tracker.iter().position(|(h, len, sent)| {
+    *h == needle && *len == needle_len && matches(reference, *sent, mode)
+  }) {
+    tracker.remove(pos);
+    true
+  } else {
+    false
+  }
+}
+
+/// Whether a reference timestamp falls inside the match window for `mode`
+/// around a recorded `sent` time.
+fn matches(reference: SystemTime, sent: SystemTime, mode: MatchMode) -> bool {
+  match reference.duration_since(sent) {
+    Ok(ahead) => ahead <= SELF_SEND_TTL,
+    Err(behind) => mode == MatchMode::Ordered && behind.duration() <= Duration::from_millis(1),
+  }
+}
+
+/// FNV-1a 64-bit content hash.
+fn fnv1a(data: &[u8]) -> u64 {
+  const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+  const PRIME: u64 = 0x0000_0100_0000_01b3;
+  let mut h = OFFSET;
+  for &b in data {
+    h ^= u64::from(b);
+    h = h.wrapping_mul(PRIME);
+  }
+  h
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn record_then_take_in_degraded_mode_matches_once() {
+    let mut t = Vec::new();
+    let now = SystemTime::now();
+    record_self_send(&mut t, b"hello", now);
+    assert!(take_self_send(
+      &mut t,
+      b"hello",
+      now + Duration::from_millis(1),
+      MatchMode::Degraded
+    ));
+    assert!(!take_self_send(
+      &mut t,
+      b"hello",
+      now + Duration::from_millis(2),
+      MatchMode::Degraded
+    ));
+  }
+
+  #[test]
+  fn ordered_pre_send_slack_admits_1ms_back() {
+    let mut t = Vec::new();
+    let now = SystemTime::now();
+    record_self_send(&mut t, b"x", now);
+    // reference 1ms BEFORE sent: Ordered mode admits (within 1ms slack)
+    assert!(take_self_send(
+      &mut t,
+      b"x",
+      now - Duration::from_millis(1),
+      MatchMode::Ordered
+    ));
+  }
+
+  #[test]
+  fn ordered_pre_send_slack_rejects_2ms_back() {
+    let mut t = Vec::new();
+    let now = SystemTime::now();
+    record_self_send(&mut t, b"x", now);
+    assert!(!take_self_send(
+      &mut t,
+      b"x",
+      now - Duration::from_millis(2),
+      MatchMode::Ordered
+    ));
+  }
+
+  #[test]
+  fn degraded_mode_rejects_negative_skew() {
+    let mut t = Vec::new();
+    let now = SystemTime::now();
+    record_self_send(&mut t, b"x", now);
+    // Degraded mode does NOT allow reference < sent
+    assert!(!take_self_send(
+      &mut t,
+      b"x",
+      now - Duration::from_millis(1),
+      MatchMode::Degraded
+    ));
+  }
+
+  #[test]
+  fn ttl_sweeps_old_entries_on_record() {
+    let mut t = Vec::new();
+    let t0 = SystemTime::now();
+    record_self_send(&mut t, b"old", t0);
+    // record a fresh entry well past TTL — old entry should be swept
+    let later = t0 + SELF_SEND_TTL + Duration::from_millis(1);
+    record_self_send(&mut t, b"new", later);
+    assert_eq!(t.len(), 1);
+    assert!(!take_self_send(&mut t, b"old", later, MatchMode::Degraded));
+    assert!(take_self_send(&mut t, b"new", later, MatchMode::Degraded));
+  }
+
+  #[test]
+  fn distinct_bodies_have_distinct_hashes() {
+    let mut t = Vec::new();
+    let now = SystemTime::now();
+    record_self_send(&mut t, b"alpha", now);
+    record_self_send(&mut t, b"beta", now);
+    assert_eq!(t.len(), 2);
+    assert!(take_self_send(&mut t, b"alpha", now, MatchMode::Degraded));
+    assert!(take_self_send(&mut t, b"beta", now, MatchMode::Degraded));
+  }
+
+  #[test]
+  fn length_mismatch_blocks_hash_only_match() {
+    let now = SystemTime::now();
+    // A synthetic entry carrying body "hello"'s hash but a WRONG length:
+    let mut t = vec![(fnv1a(b"hello"), 999u32, now)];
+    // Same hash, but the real body length (5) != stored 999 → must NOT match.
+    assert!(!take_self_send(&mut t, b"hello", now, MatchMode::Degraded));
+    // Sanity: a correctly-recorded entry still matches.
+    let mut t2 = Vec::new();
+    record_self_send(&mut t2, b"hello", now);
+    assert!(take_self_send(&mut t2, b"hello", now, MatchMode::Degraded));
+  }
+}

--- a/mdns-compio/src/service.rs
+++ b/mdns-compio/src/service.rs
@@ -1,0 +1,172 @@
+//! `Service` handle returned by [`Endpoint::register_service`].
+//!
+//! Holds an [`Rc<EndpointInner>`] + the proto-layer [`ServiceHandle`]. The
+//! driver task owns the proto `Service` state machine and per-service update
+//! queue inside `State.services`; this handle just borrows briefly to pop
+//! events or flag cancellation, then parks on the shared driver notifier when
+//! no update is ready.
+//!
+//! Dropping a [`Service`] encodes the RFC 6762 §10.1 goodbye records under a
+//! brief synchronous borrow (while the proto state still exists), pushes the
+//! encoded datagrams onto the driver's goodbye queue, frees the proto route
+//! slot, and wakes the driver — the driver's goodbye pump then multicasts the
+//! TTL=0 burst over the bound sockets before the entries drop.
+//!
+//! [`Endpoint::register_service`]: crate::Endpoint::register_service
+
+use std::rc::Rc;
+
+use mdns_proto::{ServiceHandle, ServiceUpdate};
+
+use crate::driver::EndpointInner;
+
+/// Handle to a registered service.
+///
+/// Dropping the handle implicitly unregisters the service: the proto-layer
+/// goodbye records are encoded immediately, the proto state machine is
+/// destroyed, and the driver's goodbye pump multicasts the queued TTL=0
+/// datagrams a few times (RFC 6762 §10.1) before the entries drop.
+pub struct Service {
+  pub(crate) inner: Rc<EndpointInner>,
+  pub(crate) handle: ServiceHandle,
+}
+
+impl Service {
+  /// The underlying proto-layer [`ServiceHandle`] for this registration.
+  #[inline]
+  pub const fn handle(&self) -> ServiceHandle {
+    self.handle
+  }
+
+  /// Wait for the next [`ServiceUpdate`] event, or `None` if the service has
+  /// been cancelled or the driver task exited.
+  pub async fn next(&self) -> Option<ServiceUpdate> {
+    loop {
+      // Brief synchronous borrow — pop one update, else fall through to park.
+      // The borrow is dropped at the end of this block (well before any
+      // `.await`). If the driver has removed our service entry the `?`
+      // short-circuits to `None`, signalling the handle is dead.
+      {
+        let mut st = self.inner.state.borrow_mut();
+        let ctx = st.services.get_mut(&self.handle)?;
+        if let Some(u) = ctx.updates.pop_front() {
+          return Some(u);
+        }
+        // End-of-stream once the service is withdrawn (cancelled) OR
+        // structurally dead (errored: its records can't encode into
+        // `max_payload`, see `driver::ServiceCtx::errored`). An errored service
+        // queues exactly one `Conflict` then is skipped by every driver pump and
+        // contributes no deadline or further wake — so after that `Conflict` is
+        // drained above, parking again would hang a `while let Some(u) =
+        // service.next().await` consumer forever. Surface `None` instead (codex
+        // R8; symmetric with the errored-query terminal in `Query::next`).
+        if ctx.cancelled || ctx.errored {
+          return None;
+        }
+      }
+      // No update ready: park on the driver's notify. The borrow above is
+      // already dropped, so this await never holds a RefCell borrow.
+      self.inner.notify.listen().await;
+    }
+  }
+}
+
+impl Drop for Service {
+  fn drop(&mut self) {
+    // RFC 6762 §10.1 graceful withdrawal is DRIVER-OWNED: flag the service
+    // cancelled and let the driver encode the TTL=0 goodbye + free the proto
+    // slot on its next loop iteration (`State::sweep_cancelled_services`),
+    // AFTER any send that was in flight when this handle dropped has latched
+    // its records via `note_service_transmit_result`.
+    //
+    // Encoding the goodbye synchronously here (the previous approach) raced the
+    // driver's completion-based send pump: in the thread-per-core model another
+    // task can drop this handle while the driver is parked mid-`send_to().await`
+    // for THIS service's own announce. Encoding the goodbye at that instant
+    // captures state BEFORE the announce latched as advertised, then removes the
+    // service — so when the send completes `note_service_transmit_result` is a
+    // no-op and a positive-TTL record reaches peers with no withdrawal. Deferring
+    // to the post-pump sweep closes that window.
+    {
+      let mut st = self.inner.state.borrow_mut();
+      st.flag_service_unregistered(self.handle);
+    }
+    // Durable wake (see `EndpointInner::dirty`): the withdrawal sweep + §10.1
+    // goodbye run on the next driver settle, which `dirty` guarantees happens
+    // even if this notify is lost across the driver's send-awaits.
+    self.inner.mark_dirty();
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::rc::Rc;
+
+  use mdns_proto::{Name, ServiceRecords, ServiceSpec, ServiceUpdate};
+
+  use super::Service;
+  use crate::driver::EndpointInner;
+
+  /// codex R8: once a service is flagged `errored` (its records can't encode
+  /// into `max_payload`), `Service::next` must surface end-of-stream (`None`)
+  /// after the queued `Conflict` is drained — NOT park forever. An errored
+  /// service is skipped by every driver pump and contributes no deadline or
+  /// further wake, so a `while let Some(u) = service.next().await` consumer that
+  /// re-polls after the Conflict would otherwise hang. The terminal read is
+  /// wrapped in a timeout so a regression FAILS (times out) instead of hanging
+  /// the whole suite.
+  #[compio::test]
+  async fn errored_service_next_terminates_after_conflict() {
+    let inner = EndpointInner::new(mdns_proto::EndpointConfig::default(), 1500, 9000);
+    let now = std::time::Instant::now();
+
+    let stype = Name::try_from_str("_er._tcp.local.").unwrap();
+    let inst = Name::try_from_str("E._er._tcp.local.").unwrap();
+    let host = Name::try_from_str("e.local.").unwrap();
+    let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+    recs.add_a([127, 0, 0, 1].into());
+    let handle = inner
+      .state
+      .borrow_mut()
+      .register_service(ServiceSpec::new(recs), now)
+      .unwrap();
+
+    // Simulate the escalation the transmit pump performs on persistent encode
+    // failure: queue the terminal Conflict and flag the service errored. (The
+    // full encode-failure drive is covered by the driver-level unit test;
+    // here we exercise the HANDLE terminal contract.)
+    {
+      let mut st = inner.state.borrow_mut();
+      let ctx = st.services.get_mut(&handle).unwrap();
+      ctx.updates.push_back(ServiceUpdate::Conflict);
+      ctx.errored = true;
+    }
+
+    let svc = Service {
+      inner: Rc::clone(&inner),
+      handle,
+    };
+
+    // First next(): drains the queued Conflict.
+    let first = svc.next().await;
+    assert!(
+      matches!(first, Some(ServiceUpdate::Conflict)),
+      "first next() must surface the queued Conflict, got {first:?}"
+    );
+
+    // Second next(): MUST resolve to None (end-of-stream), not park forever.
+    // The timeout turns a regression into a failure instead of a hung suite.
+    let second = compio::time::timeout(std::time::Duration::from_secs(2), svc.next()).await;
+    match second {
+      Ok(v) => assert!(
+        v.is_none(),
+        "next() after the Conflict must be end-of-stream (None), got {v:?}"
+      ),
+      Err(_) => panic!("Service::next parked forever on an errored service (R8 regression)"),
+    }
+
+    // Keep the handle alive until here so its Drop (which borrows state) runs
+    // after our assertions, not mid-test.
+    drop(svc);
+  }
+}

--- a/mdns-compio/src/socket.rs
+++ b/mdns-compio/src/socket.rs
@@ -1,0 +1,963 @@
+//! compio UdpSocket wrapper + in-crate cmsg codec (ported from compio-quic 0.7.2).
+
+#![cfg(any(unix, windows))]
+// CMsgIter/CMsgRef are wired in by T3+ (CMsgBuilder, RecvMeta, Socket); silence
+// `dead_code` until the consumers land in the same crate.
+#![allow(dead_code)]
+
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::SystemTime;
+
+#[cfg(unix)]
+use libc::{cmsghdr, msghdr};
+
+/// One ancillary control message inside a filled control buffer.
+#[cfg(unix)]
+pub(crate) struct CMsgRef<'a> {
+  inner: &'a cmsghdr,
+}
+
+#[cfg(unix)]
+impl CMsgRef<'_> {
+  #[inline]
+  pub(crate) fn level(&self) -> libc::c_int {
+    self.inner.cmsg_level
+  }
+
+  #[inline]
+  pub(crate) fn ty(&self) -> libc::c_int {
+    self.inner.cmsg_type
+  }
+
+  /// Number of payload bytes this cmsg actually carries (`cmsg_len` minus the
+  /// header/alignment offset). Saturating so a corrupt short cmsg yields 0.
+  ///
+  /// Callers must check `data_len() >= size_of::<T>()` before reading the
+  /// payload as `T` via [`CMsgRef::data`]; otherwise the read would run past
+  /// the bytes the kernel actually deposited for this cmsg.
+  #[inline]
+  pub(crate) fn data_len(&self) -> usize {
+    // SAFETY: CMSG_LEN is a pure size macro (no pointer deref).
+    let base = unsafe { libc::CMSG_LEN(0) } as usize;
+    (self.inner.cmsg_len as usize).saturating_sub(base)
+  }
+
+  /// View the cmsg payload as `T`.
+  ///
+  /// # Safety
+  ///
+  /// - Caller must guarantee `T` matches the actual cmsg payload type/size,
+  ///   and the underlying buffer must outlive any read through the returned
+  ///   pointer.
+  /// - **Alignment caveat:** `CMSG_DATA` is only guaranteed to be aligned
+  ///   to `align_of::<libc::cmsghdr>()` (4 bytes on Darwin). When
+  ///   `align_of::<T>() > align_of::<libc::cmsghdr>()` — for example
+  ///   `libc::timeval` and `libc::timespec` on Darwin, which want 8-byte
+  ///   alignment — callers MUST use `core::ptr::read_unaligned` on the
+  ///   returned pointer instead of dereferencing it. Plain `*ptr` reads
+  ///   are UB on misaligned data.
+  #[inline]
+  pub(crate) unsafe fn data<T>(&self) -> *const T {
+    // SAFETY: caller asserts T matches; CMSG_DATA returns a pointer into
+    // the same allocation as `inner`, which is borrowed for 'a. The caller
+    // is responsible for honoring T's alignment (see method-level alignment
+    // caveat above) — `*ptr` reads of misaligned data are UB, and they must
+    // use `core::ptr::read_unaligned` in that case.
+    unsafe { libc::CMSG_DATA(self.inner as *const cmsghdr) as *const T }
+  }
+}
+
+/// Iterate ancillary control messages in a filled control buffer.
+///
+/// The buffer must be aligned to `align_of::<cmsghdr>()` — see
+/// [`CMsgIter::new`]. In production this is satisfied by routing the kernel's
+/// fill through a `cmsghdr`-aligned scratch buffer (see Task 5).
+#[cfg(unix)]
+pub(crate) struct CMsgIter<'a> {
+  msg: msghdr,
+  next: *const cmsghdr,
+  _lt: core::marker::PhantomData<&'a [u8]>,
+}
+
+#[cfg(unix)]
+impl<'a> CMsgIter<'a> {
+  /// Wrap a filled control buffer for iteration.
+  ///
+  /// # Panics
+  ///
+  /// Panics if `buf` is not aligned to `align_of::<cmsghdr>()`; reading a
+  /// `cmsghdr` through a misaligned pointer is undefined behaviour, so we
+  /// refuse rather than silently invoke UB.
+  pub(crate) fn new(buf: &'a [u8]) -> Self {
+    assert!(
+      buf.as_ptr().cast::<cmsghdr>().is_aligned(),
+      "control buffer is not aligned for cmsghdr"
+    );
+    // SAFETY: msghdr's all-zero pattern is a valid empty header. We then
+    // patch the control pointer/len to point at the borrowed buffer.
+    let mut msg: msghdr = unsafe { core::mem::zeroed() };
+    msg.msg_control = buf.as_ptr() as *mut _;
+    msg.msg_controllen = buf.len() as _;
+    // SAFETY: msg has its control fields set to the borrowed buffer, which
+    // outlives 'a; CMSG_FIRSTHDR reads only those fields.
+    let next = unsafe { libc::CMSG_FIRSTHDR(&msg) } as *const cmsghdr;
+    Self {
+      msg,
+      next,
+      _lt: core::marker::PhantomData,
+    }
+  }
+}
+
+#[cfg(unix)]
+impl<'a> Iterator for CMsgIter<'a> {
+  type Item = CMsgRef<'a>;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    if self.next.is_null() {
+      return None;
+    }
+    // SAFETY: CMSG_FIRSTHDR / CMSG_NXTHDR returned a pointer inside the
+    // control buffer that outlives 'a, or null when exhausted. Alignment
+    // is ensured at `CMsgIter::new`.
+    let cur = unsafe { &*self.next };
+    // SAFETY: same as above; `next` is either a valid header pointer or
+    // null at this point. CMSG_NXTHDR walks the control buffer.
+    self.next = unsafe { libc::CMSG_NXTHDR(&self.msg, self.next) } as *const cmsghdr;
+    Some(CMsgRef { inner: cur })
+  }
+}
+
+// Windows iteration mirrors this shape over WSACMSGHDR / `WSA_CMSG_*` macros;
+// added in Task 5 alongside the Windows recv path.
+
+/// Encode outbound cmsgs into a caller-provided byte buffer.
+///
+/// The buffer must outlive any borrow of the builder; the builder writes
+/// `cmsghdr` headers and payloads in place and tracks how many bytes have been
+/// consumed. Call [`CMsgBuilder::finish`] to get the final `msg_controllen`.
+#[cfg(unix)]
+pub(crate) struct CMsgBuilder<'a> {
+  buf: &'a mut [u8],
+  cursor: usize,
+}
+
+#[cfg(unix)]
+impl<'a> CMsgBuilder<'a> {
+  /// Construct a builder over `buf`.
+  ///
+  /// # Panics
+  ///
+  /// Panics if `buf` is not aligned to `align_of::<cmsghdr>()`. Writing a
+  /// `cmsghdr` through a misaligned pointer is undefined behaviour, so we
+  /// refuse rather than silently invoke UB — mirrors [`CMsgIter::new`]'s
+  /// precondition.
+  pub(crate) fn new(buf: &'a mut [u8]) -> Self {
+    assert!(
+      buf.as_ptr().cast::<cmsghdr>().is_aligned(),
+      "control buffer is not aligned for cmsghdr"
+    );
+    // recvmsg/sendmsg expect the inter-cmsg padding bytes to be zero; just
+    // zero the whole buffer up front so subsequent CMSG_NXTHDR walks see
+    // well-defined padding.
+    for b in buf.iter_mut() {
+      *b = 0;
+    }
+    Self { buf, cursor: 0 }
+  }
+
+  /// Append a cmsg with payload `value: T`.
+  ///
+  /// Returns `Err(())` if the buffer doesn't have `CMSG_SPACE(sizeof T)` bytes
+  /// remaining (i.e. the cmsg wouldn't fit). On success, the cursor advances
+  /// past the encoded cmsg + alignment padding.
+  pub(crate) fn push<T: Copy>(
+    &mut self,
+    level: libc::c_int,
+    ty: libc::c_int,
+    value: &T,
+  ) -> Result<(), ()> {
+    let payload_bytes = core::mem::size_of::<T>();
+    // SAFETY: CMSG_SPACE is a pure macro over its size argument; no pointers.
+    let space = unsafe { libc::CMSG_SPACE(payload_bytes as u32) } as usize;
+    let end = self.cursor.checked_add(space).ok_or(())?;
+    if end > self.buf.len() {
+      return Err(());
+    }
+    // SAFETY: we just bounds-checked `space`, and `new()` enforced that the
+    // buffer is aligned to `align_of::<cmsghdr>()`, so the header store at
+    // `buf + cursor` honours `cmsghdr`'s alignment. `CMSG_DATA(hdr)` only
+    // guarantees `cmsghdr`-alignment for the payload — which may be looser
+    // than `align_of::<T>()` (e.g. `timeval` on Darwin) — so the payload is
+    // written via `write_unaligned`, matching the rule documented on
+    // [`CMsgRef::data`].
+    unsafe {
+      let hdr = self.buf.as_mut_ptr().add(self.cursor) as *mut cmsghdr;
+      (*hdr).cmsg_len = libc::CMSG_LEN(payload_bytes as u32) as _;
+      (*hdr).cmsg_level = level;
+      (*hdr).cmsg_type = ty;
+      let data = libc::CMSG_DATA(hdr) as *mut T;
+      core::ptr::write_unaligned(data, *value);
+    }
+    self.cursor = end;
+    Ok(())
+  }
+
+  /// Consume the builder and return the number of bytes written, i.e. the
+  /// `msg_controllen` value to hand to `sendmsg`.
+  #[inline]
+  pub(crate) fn finish(self) -> usize {
+    self.cursor
+  }
+}
+
+/// Decoded recv metadata pulled from cmsgs.
+///
+/// Reachable from `mdns_compio::__test` for integration tests; the public
+/// surface of the driver is added in T10 / T24.
+#[derive(Debug, Clone, Copy)]
+pub struct RecvMeta {
+  /// The peer that sent the datagram.
+  pub peer: SocketAddr,
+  /// The destination address recorded by the kernel (from PKTINFO).
+  pub local_ip: IpAddr,
+  /// Receiving interface index, taken from PKTINFO.
+  pub interface_index: u32,
+  /// IP TTL / IPv6 hop limit if the kernel exposed it.
+  pub hop_limit: Option<u8>,
+  /// Kernel-stamped rx time (SO_TIMESTAMP / SO_TIMESTAMPNS).
+  pub kernel_rx_time: Option<SystemTime>,
+  /// Bytes of payload received.
+  pub len: usize,
+}
+
+impl RecvMeta {
+  pub(crate) fn empty(peer: SocketAddr) -> Self {
+    let local_ip = match peer {
+      SocketAddr::V4(_) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+      SocketAddr::V6(_) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+    };
+    Self {
+      peer,
+      local_ip,
+      interface_index: 0,
+      hop_limit: None,
+      kernel_rx_time: None,
+      len: 0,
+    }
+  }
+}
+
+/// `compio` UDP socket wrapper + cmsg-aware recv/send.
+///
+/// The constructor enables the kernel ancillary-data options needed by the
+/// driver (PKTINFO for the receiving interface, RECVTTL/HOPLIMIT for RFC 6762
+/// §11 on-link checks, and `SO_TIMESTAMP`/`SO_TIMESTAMPNS` for ordered
+/// self-send classification) and then wraps the file descriptor as a
+/// `compio` socket.
+///
+/// Reachable from `mdns_compio::__test` for integration tests; the public
+/// surface of the driver is added in T10 / T24.
+pub struct Socket {
+  inner: compio_net::UdpSocket,
+}
+
+impl Socket {
+  /// Wrap an already-bound + joined `std::net::UdpSocket`, enabling cmsg recv
+  /// options. Mirrors `compio-quic 0.7.2` socket construction.
+  pub async fn from_std(sock: std::net::UdpSocket) -> std::io::Result<Self> {
+    sock.set_nonblocking(true)?;
+    #[cfg(unix)]
+    {
+      enable_recv_cmsgs(&sock)?;
+    }
+    let inner = compio_net::UdpSocket::from_std(sock)?;
+    Ok(Self { inner })
+  }
+
+  /// One `recv_msg` with a 256-byte ancillary buffer; decode the metadata
+  /// into [`RecvMeta`]. Owns its data + control buffers across the completion.
+  ///
+  /// Control buffer is backed by an `AlignedCtrlBuf` newtype that wraps a
+  /// `[u8; 256]` inside a `#[repr(align(8))]` struct — guaranteeing the
+  /// `cmsghdr` alignment that [`CMsgIter::new`] / `compio-net`'s `recv_msg`
+  /// both require.
+  pub async fn recv(&self, max: usize) -> std::io::Result<(Vec<u8>, RecvMeta)> {
+    let buf: Vec<u8> = Vec::with_capacity(max);
+    #[cfg(unix)]
+    {
+      let ctrl = AlignedCtrlBuf::new();
+      let compio_buf::BufResult(res, (buf, ctrl)) = self.inner.recv_msg(buf, ctrl).await;
+      let (data_len, ctrl_len, peer) = res?;
+      let mut data = buf;
+      // `compio-buf`'s `advance_vec_to` already set `data.len() = data_len`
+      // through the `[Vec<u8>; 1]` SetLen impl, but truncate defensively.
+      if data.len() > data_len {
+        data.truncate(data_len);
+      }
+      let mut meta = RecvMeta::empty(peer);
+      meta.len = data_len;
+      let ctrl_bytes = ctrl.filled(ctrl_len);
+      decode_unix_cmsgs(ctrl_bytes, &mut meta);
+      Ok((data, meta))
+    }
+    #[cfg(not(unix))]
+    {
+      // Windows: no cmsg plumbing yet. Fall back to plain `recv_from` and
+      // leave the per-packet PKTINFO / TTL fields empty. The driver still
+      // works for loopback / single-interface scenarios; a proper Windows
+      // port (WSARecvMsg + WSACMSG_FIRSTHDR) is a follow-up task.
+      let compio_buf::BufResult(res, buf) = self.inner.recv_from(buf).await;
+      let (data_len, peer) = res?;
+      let mut data = buf;
+      if data.len() > data_len {
+        data.truncate(data_len);
+      }
+      let mut meta = RecvMeta::empty(peer);
+      meta.len = data_len;
+      Ok((data, meta))
+    }
+  }
+
+  /// Send `buf` to `dst`, optionally with caller-provided cmsg bytes
+  /// already encoded via [`CMsgBuilder`]. The cmsg payload is copied into
+  /// a stack-aligned [`AlignedCtrlBuf`] so callers may pass a borrowed
+  /// slice that came from any allocator.
+  pub async fn send_to(
+    &self,
+    buf: &[u8],
+    dst: core::net::SocketAddr,
+    ctrl: Option<&[u8]>,
+  ) -> std::io::Result<usize> {
+    let data = buf.to_vec();
+    match ctrl {
+      #[cfg(unix)]
+      Some(c) if !c.is_empty() => {
+        let ctrl_buf = AlignedCtrlBuf::from_slice(c);
+        let compio_buf::BufResult(res, _) = self.inner.send_msg(data, ctrl_buf, dst).await;
+        res
+      }
+      #[cfg(not(unix))]
+      Some(_) => {
+        // Windows: ignore caller-provided cmsg payload (PKTINFO/HOPLIMIT) and
+        // fall back to plain send. The kernel picks the egress interface based
+        // on the routing table; a proper Windows port (WSASendMsg) is a
+        // follow-up task.
+        let compio_buf::BufResult(res, _) = self.inner.send_to(data, dst).await;
+        res
+      }
+      _ => {
+        let compio_buf::BufResult(res, _) = self.inner.send_to(data, dst).await;
+        res
+      }
+    }
+  }
+}
+
+/// Boxed 256-byte ancillary buffer whose backing storage is ≥8-byte aligned,
+/// which is what `compio-net`'s `recv_msg` / `send_msg` assert for the
+/// control parameter and what [`CMsgIter::new`] requires for sound walking.
+///
+/// `Vec<u8>::with_capacity` does not guarantee anything beyond alignment 1
+/// in the type system, so we own a `Box<AlignedStorage>` whose inner type is
+/// a `#[repr(align(8))]` array. The wrapper implements `IoBuf` / `IoBufMut`
+/// / `SetLen` over a manually tracked `init_len`; `SetLen::set_len` accepts
+/// values up to `CMSG_CAP` and never resizes (the buffer is fixed-size).
+#[cfg(unix)]
+struct AlignedCtrlBuf {
+  storage: Box<AlignedCtrlStorage>,
+  init_len: usize,
+}
+
+#[cfg(unix)]
+const CMSG_CAP: usize = 256;
+
+#[cfg(unix)]
+#[repr(align(8))]
+struct AlignedCtrlStorage([u8; CMSG_CAP]);
+
+#[cfg(unix)]
+impl AlignedCtrlBuf {
+  fn new() -> Self {
+    Self {
+      storage: Box::new(AlignedCtrlStorage([0u8; CMSG_CAP])),
+      init_len: 0,
+    }
+  }
+
+  /// Build a control buffer pre-filled with `src` (used for `send_msg`).
+  ///
+  /// # Panics
+  ///
+  /// Panics if `src.len() > CMSG_CAP` — outbound mDNS cmsgs (PKTINFO,
+  /// HOPLIMIT) are well under that, so the static cap is fine.
+  fn from_slice(src: &[u8]) -> Self {
+    assert!(
+      src.len() <= CMSG_CAP,
+      "outbound cmsg payload {} exceeds CMSG_CAP={CMSG_CAP}",
+      src.len()
+    );
+    let mut buf = Self::new();
+    buf.storage.0[..src.len()].copy_from_slice(src);
+    buf.init_len = src.len();
+    buf
+  }
+
+  /// Return the initialised portion as a `&[u8]`, clamped to the actual
+  /// fill length reported by the kernel.
+  fn filled(&self, kernel_len: usize) -> &[u8] {
+    let n = kernel_len.min(CMSG_CAP);
+    &self.storage.0[..n]
+  }
+}
+
+#[cfg(unix)]
+impl compio_buf::IoBuf for AlignedCtrlBuf {
+  fn as_init(&self) -> &[u8] {
+    &self.storage.0[..self.init_len]
+  }
+}
+
+#[cfg(unix)]
+impl compio_buf::IoBufMut for AlignedCtrlBuf {
+  fn as_uninit(&mut self) -> &mut [core::mem::MaybeUninit<u8>] {
+    let ptr = self.storage.0.as_mut_ptr() as *mut core::mem::MaybeUninit<u8>;
+    // SAFETY: `storage` owns a fixed `[u8; CMSG_CAP]` (all zeroed at
+    // construction), so the pointer is valid for `CMSG_CAP` bytes and the
+    // bytes are initialised — treating them as `MaybeUninit<u8>` is sound.
+    unsafe { core::slice::from_raw_parts_mut(ptr, CMSG_CAP) }
+  }
+}
+
+#[cfg(unix)]
+impl compio_buf::SetLen for AlignedCtrlBuf {
+  unsafe fn set_len(&mut self, len: usize) {
+    debug_assert!(len <= CMSG_CAP);
+    self.init_len = len.min(CMSG_CAP);
+  }
+}
+
+#[cfg(unix)]
+fn enable_recv_cmsgs(sock: &std::net::UdpSocket) -> std::io::Result<()> {
+  use std::os::fd::AsRawFd;
+  let fd = sock.as_raw_fd();
+  let on: libc::c_int = 1;
+  // Apply ONLY the cmsg options for this socket's address family. The IPv4
+  // options (`IPPROTO_IP`/`IP_PKTINFO`/`IP_RECVTTL`) return `EINVAL` on an
+  // `AF_INET6` socket and vice-versa, so a blanket apply made every v6-only /
+  // dual-stack endpoint fail construction (the wrong-family `setsockopt`
+  // bubbled up through `from_std` before any datagram could flow). mDNS binds
+  // a separate single-family socket per family, so `local_addr` is the
+  // authoritative family selector.
+  //
+  // The capability `cfg`s (emitted by `build.rs`) compose WITH this runtime
+  // family check: a cfg gates "does this target define the constant at all"
+  // (so an exotic Unix that lacks it still compiles), while `is_v6` gates "is
+  // this socket that family" (so we never apply the wrong-family option). Both
+  // are required. `fd`/`on`/`is_v6` are touched unconditionally below so they
+  // never read as unused on a target where every option's cfg is off.
+  let is_v6 = matches!(sock.local_addr()?, std::net::SocketAddr::V6(_));
+  let _ = (fd, on, is_v6);
+  if is_v6 {
+    // IPV6_RECVPKTINFO — destination address + interface index. Only where
+    // libc defines IPV6_PKTINFO (`has_ipv6_pktinfo`).
+    #[cfg(has_ipv6_pktinfo)]
+    set_int(fd, libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO, on)?;
+    // IPV6_RECVHOPLIMIT — hop limit for the §11 on-link check. Only where libc
+    // defines the hop-limit cmsg (`has_recv_hoplimit`; absent on OpenBSD/NetBSD).
+    #[cfg(has_recv_hoplimit)]
+    set_int(fd, libc::IPPROTO_IPV6, libc::IPV6_RECVHOPLIMIT, on)?;
+  } else {
+    // IP_PKTINFO — destination address + interface index. Only where libc
+    // defines the shared in_pktinfo layout (`has_ip_pktinfo`; BSDs excluded).
+    #[cfg(has_ip_pktinfo)]
+    set_int(fd, libc::IPPROTO_IP, libc::IP_PKTINFO, on)?;
+    // IP_RECVTTL — TTL for the §11 on-link check. Only where libc defines the
+    // hop-limit cmsg (`has_recv_hoplimit`; absent on OpenBSD/NetBSD).
+    #[cfg(has_recv_hoplimit)]
+    set_int(fd, libc::IPPROTO_IP, libc::IP_RECVTTL, on)?;
+  }
+  // SO_TIMESTAMP[NS] — kernel rx time for ordered self-send classification.
+  // Family-agnostic (`SOL_SOCKET`); best-effort, the recv path degrades to
+  // read-time when it is absent. We ENABLE via the SO_* sockopt (the kernel
+  // then tags the received cmsg with the matching SCM_* type, which
+  // `decode_unix_cmsgs` matches). `recv_timestamp_ns` selects the nanosecond
+  // SO_TIMESTAMPNS (Linux/Android) over the microsecond SO_TIMESTAMP.
+  #[cfg(all(has_recv_timestamp, recv_timestamp_ns))]
+  set_int(fd, libc::SOL_SOCKET, libc::SO_TIMESTAMPNS, on).ok();
+  #[cfg(all(has_recv_timestamp, not(recv_timestamp_ns)))]
+  set_int(fd, libc::SOL_SOCKET, libc::SO_TIMESTAMP, on).ok();
+  Ok(())
+}
+
+#[cfg(unix)]
+fn set_int(
+  fd: std::os::fd::RawFd,
+  level: libc::c_int,
+  optname: libc::c_int,
+  val: libc::c_int,
+) -> std::io::Result<()> {
+  // SAFETY: `&val` is a valid pointer to a `c_int`, passed with the matching length.
+  let rc = unsafe {
+    libc::setsockopt(
+      fd,
+      level,
+      optname,
+      &val as *const _ as *const _,
+      core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+    )
+  };
+  if rc != 0 {
+    Err(std::io::Error::last_os_error())
+  } else {
+    Ok(())
+  }
+}
+
+#[cfg(unix)]
+fn decode_unix_cmsgs(ctrl: &[u8], meta: &mut RecvMeta) {
+  // `ctrl` originates from `AlignedCtrlBuf::filled`, whose storage is the
+  // start of a `#[repr(align(8))]` array — so the slice's first byte is
+  // aligned for `cmsghdr`. Defensive bail for the rare future caller that
+  // doesn't honour that invariant.
+  if ctrl.is_empty() {
+    return;
+  }
+  if !ctrl.as_ptr().cast::<libc::cmsghdr>().is_aligned() {
+    return;
+  }
+  for c in CMsgIter::new(ctrl) {
+    match (c.level(), c.ty()) {
+      // IPv4 PKTINFO — only where libc defines the shared in_pktinfo layout
+      // (`has_ip_pktinfo`; BSDs excluded — see build.rs).
+      #[cfg(has_ip_pktinfo)]
+      (libc::IPPROTO_IP, libc::IP_PKTINFO) => {
+        if c.data_len() < core::mem::size_of::<libc::in_pktinfo>() {
+          continue;
+        }
+        // SAFETY: kernel writes `in_pktinfo` for the `IP_PKTINFO` cmsg, and the
+        // length guard above ensures the cmsg carries at least
+        // `size_of::<in_pktinfo>()` payload bytes before this read. CMSG_DATA
+        // is only `cmsghdr`-aligned, so use `read_unaligned`.
+        let pi = unsafe { core::ptr::read_unaligned(c.data::<libc::in_pktinfo>()) };
+        meta.local_ip = IpAddr::V4(Ipv4Addr::from(u32::from_be(pi.ipi_spec_dst.s_addr)));
+        meta.interface_index = pi.ipi_ifindex as u32;
+      }
+      // IPv6 PKTINFO — only where libc defines IPV6_PKTINFO (`has_ipv6_pktinfo`).
+      #[cfg(has_ipv6_pktinfo)]
+      (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
+        if c.data_len() < core::mem::size_of::<libc::in6_pktinfo>() {
+          continue;
+        }
+        // SAFETY: kernel writes `in6_pktinfo` for the `IPV6_PKTINFO` cmsg, and
+        // the length guard above ensures the payload is at least
+        // `size_of::<in6_pktinfo>()` bytes before this read.
+        let pi = unsafe { core::ptr::read_unaligned(c.data::<libc::in6_pktinfo>()) };
+        meta.local_ip = IpAddr::V6(Ipv6Addr::from(pi.ipi6_addr.s6_addr));
+        meta.interface_index = pi.ipi6_ifindex as u32;
+      }
+      // IPv4 TTL — only where libc defines the hop-limit cmsg constants
+      // (`has_recv_hoplimit`; absent on OpenBSD/NetBSD).
+      #[cfg(has_recv_hoplimit)]
+      (libc::IPPROTO_IP, libc::IP_TTL) | (libc::IPPROTO_IP, libc::IP_RECVTTL) => {
+        if c.data_len() < core::mem::size_of::<libc::c_int>() {
+          continue;
+        }
+        // SAFETY: kernel writes a `c_int` for `IP_TTL` / `IP_RECVTTL`, and the
+        // length guard above ensures at least `size_of::<c_int>()` payload
+        // bytes are present before this read.
+        let v = unsafe { core::ptr::read_unaligned(c.data::<libc::c_int>()) };
+        meta.hop_limit = Some(v as u8);
+      }
+      // IPv6 Hop Limit — same `has_recv_hoplimit` gate as the IPv4 TTL arm.
+      #[cfg(has_recv_hoplimit)]
+      (libc::IPPROTO_IPV6, libc::IPV6_HOPLIMIT) => {
+        if c.data_len() < core::mem::size_of::<libc::c_int>() {
+          continue;
+        }
+        // SAFETY: kernel writes a `c_int` for `IPV6_HOPLIMIT`, and the length
+        // guard above ensures at least `size_of::<c_int>()` payload bytes are
+        // present before this read.
+        let v = unsafe { core::ptr::read_unaligned(c.data::<libc::c_int>()) };
+        meta.hop_limit = Some(v as u8);
+      }
+      // Kernel receive timestamp. The kernel tags the cmsg with the SCM_* TYPE,
+      // which is NOT always equal to the SO_* sockopt used to enable it
+      // (Linux happens to share values; on Darwin/BSD SCM_TIMESTAMP == 0x02 !=
+      // SO_TIMESTAMP). Match the SCM_* type the kernel actually delivers.
+      // `recv_timestamp_ns` selects the nanosecond SCM_TIMESTAMPNS (timespec,
+      // Linux/Android) over the microsecond SCM_TIMESTAMP (timeval, Apple/BSD).
+      #[cfg(all(has_recv_timestamp, recv_timestamp_ns))]
+      (libc::SOL_SOCKET, libc::SCM_TIMESTAMPNS) => {
+        if c.data_len() < core::mem::size_of::<libc::timespec>() {
+          continue;
+        }
+        // SAFETY: kernel writes a `timespec` for `SCM_TIMESTAMPNS`, and the
+        // length guard above ensures at least `size_of::<timespec>()` payload
+        // bytes are present before this read.
+        let ts = unsafe { core::ptr::read_unaligned(c.data::<libc::timespec>()) };
+        // Checked arithmetic so a garbage `tv_sec`/`tv_nsec` declines the stamp
+        // (leaving `kernel_rx_time` untouched) instead of panicking the driver.
+        let nanos = u32::try_from(ts.tv_nsec).unwrap_or(0).min(999_999_999);
+        if let Ok(secs) = u64::try_from(ts.tv_sec) {
+          meta.kernel_rx_time =
+            std::time::UNIX_EPOCH.checked_add(std::time::Duration::new(secs, nanos));
+        }
+      }
+      #[cfg(all(has_recv_timestamp, not(recv_timestamp_ns)))]
+      (libc::SOL_SOCKET, libc::SCM_TIMESTAMP) => {
+        if c.data_len() < core::mem::size_of::<libc::timeval>() {
+          continue;
+        }
+        // SAFETY: kernel writes a `timeval` for `SCM_TIMESTAMP`, and the length
+        // guard above ensures at least `size_of::<timeval>()` payload bytes are
+        // present before this read.
+        let tv = unsafe { core::ptr::read_unaligned(c.data::<libc::timeval>()) };
+        // Checked arithmetic so a garbage `tv_sec`/`tv_usec` declines the stamp
+        // (leaving `kernel_rx_time` untouched) instead of panicking the driver.
+        let micros = u32::try_from(tv.tv_usec).unwrap_or(0).min(999_999);
+        if let Ok(secs) = u64::try_from(tv.tv_sec) {
+          meta.kernel_rx_time =
+            std::time::UNIX_EPOCH.checked_add(std::time::Duration::new(secs, micros * 1000));
+        }
+      }
+      _ => {}
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Regression for the family-blind cmsg setup: `enable_recv_cmsgs` used to
+  /// apply the IPv4-only `IP_PKTINFO` / `IP_RECVTTL` sockopts with a fatal `?`
+  /// to EVERY socket, so an `AF_INET6` socket failed with `EINVAL` and
+  /// `from_std` bubbled the error — breaking v6-only and dual-stack endpoint
+  /// construction before any datagram could flow. `from_std` must now succeed on
+  /// a v6 socket by applying only the v6 cmsg options.
+  #[cfg(unix)]
+  #[compio::test]
+  async fn from_std_enables_cmsgs_on_v6_socket() {
+    use std::net::{Ipv6Addr, UdpSocket};
+    let sock = match UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)) {
+      Ok(s) => s,
+      Err(_) => return, // host without usable IPv6 — environmental skip
+    };
+    let wrapped = Socket::from_std(sock).await;
+    assert!(
+      wrapped.is_ok(),
+      "from_std must enable cmsgs on a v6 socket without EINVAL, got {:?}",
+      wrapped.err()
+    );
+  }
+
+  /// Companion to [`from_std_enables_cmsgs_on_v6_socket`]: the per-family gating
+  /// must not regress the v4 path.
+  #[cfg(unix)]
+  #[compio::test]
+  async fn from_std_enables_cmsgs_on_v4_socket() {
+    use std::net::{Ipv4Addr, UdpSocket};
+    let sock = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind v4");
+    let wrapped = Socket::from_std(sock).await;
+    assert!(
+      wrapped.is_ok(),
+      "from_std must still succeed on a v4 socket, got {:?}",
+      wrapped.err()
+    );
+  }
+
+  /// Build a minimal control buffer containing a single SOL_SOCKET receive-
+  /// timestamp cmsg (the SCM_* TYPE the kernel actually delivers — and that
+  /// `decode_unix_cmsgs` matches), then iterate it and verify level/type/data.
+  /// The constant + payload are chosen by `recv_timestamp_ns`: nanosecond
+  /// SCM_TIMESTAMPNS/timespec on Linux/Android, microsecond SCM_TIMESTAMP/timeval
+  /// on Apple/BSD.
+  #[cfg(all(unix, has_recv_timestamp))]
+  #[test]
+  fn cmsg_iter_walks_a_single_timestamp_cmsg() {
+    #[cfg(not(recv_timestamp_ns))]
+    use libc::{SCM_TIMESTAMP as TS_TYPE, timeval as TsPayload};
+    #[cfg(recv_timestamp_ns)]
+    use libc::{SCM_TIMESTAMPNS as TS_TYPE, timespec as TsPayload};
+    use libc::{SOL_SOCKET, cmsghdr};
+    #[cfg(recv_timestamp_ns)]
+    let payload = TsPayload {
+      tv_sec: 1234,
+      tv_nsec: 56,
+    };
+    #[cfg(not(recv_timestamp_ns))]
+    let payload = TsPayload {
+      tv_sec: 1234,
+      tv_usec: 56,
+    };
+    let payload_bytes = core::mem::size_of::<TsPayload>();
+    let total = unsafe { libc::CMSG_SPACE(payload_bytes as u32) } as usize;
+    // Use a u64-backed allocation to guarantee at least 8-byte alignment,
+    // which covers every cmsghdr alignment on supported targets. A plain
+    // `vec![0u8; total]` is only alignment 1 and would trip CMsgIter::new.
+    assert!(core::mem::align_of::<cmsghdr>() <= core::mem::align_of::<u64>());
+    let words = total.div_ceil(core::mem::size_of::<u64>());
+    let mut backing: Vec<u64> = vec![0u64; words.max(1)];
+    // SAFETY: backing owns `words * 8` zeroed bytes; `total <= words * 8`,
+    // so the resulting slice fits inside the allocation. The bytes stay
+    // borrowed for the lifetime of this scope.
+    let buf: &mut [u8] =
+      unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), total) };
+    // SAFETY: buf is correctly sized and zero-initialised; we write a valid cmsghdr.
+    // The header pointer is aligned (Vec<u64> backing), but CMSG_DATA may be
+    // under-aligned for the payload type (`timeval` on macOS), so use
+    // `write_unaligned` to match the eventual `read_unaligned` below.
+    unsafe {
+      let hdr = buf.as_mut_ptr() as *mut cmsghdr;
+      (*hdr).cmsg_len = libc::CMSG_LEN(payload_bytes as u32) as _;
+      (*hdr).cmsg_level = SOL_SOCKET;
+      (*hdr).cmsg_type = TS_TYPE;
+      let data = libc::CMSG_DATA(hdr) as *mut TsPayload;
+      core::ptr::write_unaligned(data, payload);
+    }
+    let mut iter = CMsgIter::new(buf);
+    let first = iter.next().expect("one cmsg");
+    assert_eq!(first.level(), SOL_SOCKET);
+    assert_eq!(first.ty(), TS_TYPE);
+    // CMSG_DATA is only guaranteed to satisfy cmsghdr's alignment, not the
+    // payload type's. On macOS `cmsghdr` is 4-byte aligned and `timeval`
+    // wants 8 — read unaligned to stay sound across all targets.
+    let got = unsafe { core::ptr::read_unaligned(first.data::<TsPayload>()) };
+    assert_eq!(got.tv_sec, 1234);
+    #[cfg(recv_timestamp_ns)]
+    assert_eq!(got.tv_nsec, 56);
+    #[cfg(not(recv_timestamp_ns))]
+    assert_eq!(got.tv_usec, 56);
+    assert!(iter.next().is_none(), "no second cmsg");
+  }
+
+  /// Round-trip an `IP_PKTINFO` cmsg through `CMsgBuilder` and `CMsgIter`:
+  /// the builder encodes the header + payload, then the iterator must read
+  /// back the same level/type/payload.
+  #[cfg(unix)]
+  #[test]
+  fn cmsg_builder_emits_a_round_trippable_pktinfo() {
+    use libc::{IP_PKTINFO, IPPROTO_IP, in_addr, in_pktinfo};
+    let pktinfo = in_pktinfo {
+      ipi_ifindex: 7,
+      ipi_spec_dst: in_addr {
+        s_addr: u32::from_be_bytes([127, 0, 0, 1]).to_be(),
+      },
+      ipi_addr: in_addr {
+        s_addr: u32::from_be_bytes([127, 0, 0, 1]).to_be(),
+      },
+    };
+    // `vec![0u8; 128]` is only alignment 1, which would trip CMsgIter::new's
+    // alignment assert. Mirror the T2 pattern and back the buffer with a
+    // `Vec<u64>` to get ≥8-byte alignment for the underlying bytes.
+    assert!(core::mem::align_of::<cmsghdr>() <= core::mem::align_of::<u64>());
+    let mut backing: Vec<u64> = vec![0u64; 128 / core::mem::size_of::<u64>()];
+    // SAFETY: backing owns `len * 8 == 128` zeroed bytes; the resulting slice
+    // is borrowed for the rest of this scope and never aliased.
+    let buf: &mut [u8] =
+      unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), 128) };
+    let written = {
+      let mut b = CMsgBuilder::new(buf);
+      b.push(IPPROTO_IP, IP_PKTINFO, &pktinfo).expect("fits");
+      b.finish()
+    };
+    assert!(written > 0);
+    let mut iter = CMsgIter::new(&buf[..written]);
+    let cmsg = iter.next().expect("round-tripped one cmsg");
+    assert_eq!(cmsg.level(), IPPROTO_IP);
+    assert_eq!(cmsg.ty(), IP_PKTINFO);
+    // CMSG_DATA is only guaranteed to satisfy cmsghdr's alignment; on macOS
+    // `cmsghdr` aligns to 4, and `in_pktinfo` also aligns to 4, so this is
+    // fine in practice — but use `read_unaligned` defensively to mirror the
+    // builder's `write_unaligned`.
+    let got = unsafe { core::ptr::read_unaligned(cmsg.data::<in_pktinfo>()) };
+    assert_eq!(got.ipi_ifindex, 7);
+    assert!(iter.next().is_none(), "no second cmsg");
+  }
+
+  /// A cmsg that advertises `IPPROTO_IP` / `IP_PKTINFO` but whose `cmsg_len`
+  /// only covers 2 payload bytes (far short of `in_pktinfo`) must be skipped,
+  /// not read: reading `in_pktinfo` out of it would run past the bytes the
+  /// kernel deposited. `decode_unix_cmsgs` must return without panicking and
+  /// leave `local_ip` / `interface_index` at their `RecvMeta::empty` defaults.
+  #[cfg(unix)]
+  #[test]
+  fn truncated_pktinfo_cmsg_is_skipped_not_read() {
+    use libc::{IP_PKTINFO, IPPROTO_IP, cmsghdr};
+    // Reserve room for a full `in_pktinfo` payload so the buffer itself is
+    // large enough; only `cmsg_len` is shrunk to claim a 2-byte payload, which
+    // is what makes the cmsg "truncated" from the decoder's point of view.
+    let payload_bytes = core::mem::size_of::<libc::in_pktinfo>();
+    let total = unsafe { libc::CMSG_SPACE(payload_bytes as u32) } as usize;
+    // Back with a `Vec<u64>` for ≥8-byte alignment, mirroring the iterator
+    // tests above; a plain `vec![0u8; total]` is only alignment 1 and would
+    // trip `decode_unix_cmsgs`'s alignment guard / `CMsgIter::new`.
+    assert!(core::mem::align_of::<cmsghdr>() <= core::mem::align_of::<u64>());
+    let words = total.div_ceil(core::mem::size_of::<u64>());
+    let mut backing: Vec<u64> = vec![0u64; words.max(1)];
+    // SAFETY: backing owns `words * 8 >= total` zeroed bytes; the slice fits
+    // inside the allocation and stays borrowed for this scope.
+    let buf: &mut [u8] =
+      unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), total) };
+    // SAFETY: buf is sized for a full `in_pktinfo` cmsg and zero-initialised;
+    // we write a valid header but set `cmsg_len = CMSG_LEN(2)` so the cmsg
+    // claims only 2 payload bytes.
+    unsafe {
+      let hdr = buf.as_mut_ptr() as *mut cmsghdr;
+      (*hdr).cmsg_len = libc::CMSG_LEN(2) as _;
+      (*hdr).cmsg_level = IPPROTO_IP;
+      (*hdr).cmsg_type = IP_PKTINFO;
+    }
+    let mut meta = RecvMeta::empty(([0u8, 0, 0, 0], 0).into());
+    decode_unix_cmsgs(buf, &mut meta);
+    // Left at defaults: the truncated cmsg was skipped, never read as garbage.
+    assert!(
+      meta.local_ip.is_unspecified(),
+      "truncated PKTINFO populated local_ip from a short cmsg"
+    );
+    assert_eq!(
+      meta.interface_index, 0,
+      "truncated PKTINFO populated interface_index from a short cmsg"
+    );
+  }
+
+  /// An absurd, malformed timestamp cmsg must not panic the decoder. Two
+  /// panic vectors are exercised at once: `tv_sec = i64::MAX` (which the old
+  /// `UNIX_EPOCH + Duration` `Add` could overflow-panic on) and an
+  /// out-of-range sub-second field (`tv_nsec`/`tv_usec` far past its modulus,
+  /// which the old `Duration::new(secs, nanos)` could carry-overflow-panic on).
+  /// The checked/clamped arithmetic must absorb both: reaching the final
+  /// assertion at all proves no panic. We then require `kernel_rx_time` to be
+  /// well-defined — either declined (`None`, if the platform's `SystemTime`
+  /// range overflowed) or a valid stamp — but never a panic.
+  ///
+  /// Note: we do *not* hard-assert `None`. `tv_sec`/`tv_nsec` are `i64`/`i64`
+  /// (`time_t`), and on Linux/Darwin `UNIX_EPOCH.checked_add(Duration::new(
+  /// i64::MAX as u64, _))` stays in range and returns `Some`; `None` is only
+  /// reachable with a seconds value larger than `i64` can hold, which a real
+  /// kernel timestamp field cannot carry. The fix's guarantee is "no panic",
+  /// not a forced `None`.
+  #[cfg(all(unix, has_recv_timestamp))]
+  #[test]
+  fn absurd_timestamp_does_not_panic() {
+    use libc::{SOL_SOCKET, cmsghdr};
+
+    // Use the SCM_* TYPE the decoder now matches (the kernel-delivered cmsg
+    // type), selected by `recv_timestamp_ns` like the decode arms.
+    #[cfg(not(recv_timestamp_ns))]
+    use libc::{SCM_TIMESTAMP as TS_TYPE, timeval as TsPayload};
+    #[cfg(recv_timestamp_ns)]
+    use libc::{SCM_TIMESTAMPNS as TS_TYPE, timespec as TsPayload};
+
+    // `tv_sec = i64::MAX` plus an out-of-range sub-second value: the latter is
+    // exactly the input `Duration::new` would reject by panicking (nanos must
+    // be < 1e9), so the decoder's clamp is what keeps this sound.
+    #[cfg(recv_timestamp_ns)]
+    let payload = TsPayload {
+      tv_sec: i64::MAX,
+      tv_nsec: i64::MAX,
+    };
+    #[cfg(not(recv_timestamp_ns))]
+    let payload = TsPayload {
+      tv_sec: i64::MAX as _,
+      tv_usec: i64::MAX as _,
+    };
+
+    let payload_bytes = core::mem::size_of::<TsPayload>();
+    let total = unsafe { libc::CMSG_SPACE(payload_bytes as u32) } as usize;
+    assert!(core::mem::align_of::<cmsghdr>() <= core::mem::align_of::<u64>());
+    let words = total.div_ceil(core::mem::size_of::<u64>());
+    let mut backing: Vec<u64> = vec![0u64; words.max(1)];
+    // SAFETY: backing owns `words * 8 >= total` zeroed bytes; the slice fits
+    // inside the allocation and stays borrowed for this scope.
+    let buf: &mut [u8] =
+      unsafe { core::slice::from_raw_parts_mut(backing.as_mut_ptr().cast::<u8>(), total) };
+    // SAFETY: buf is correctly sized and zero-initialised; we write a valid
+    // header and an absurd-but-well-formed payload via `write_unaligned`
+    // (CMSG_DATA may be under-aligned for the payload type on some targets).
+    unsafe {
+      let hdr = buf.as_mut_ptr() as *mut cmsghdr;
+      (*hdr).cmsg_len = libc::CMSG_LEN(payload_bytes as u32) as _;
+      (*hdr).cmsg_level = SOL_SOCKET;
+      (*hdr).cmsg_type = TS_TYPE;
+      let data = libc::CMSG_DATA(hdr) as *mut TsPayload;
+      core::ptr::write_unaligned(data, payload);
+    }
+    let mut meta = RecvMeta::empty(([0u8, 0, 0, 0], 0).into());
+    // Must return without panicking despite the absurd seconds + out-of-range
+    // sub-second field. Reaching the line after this call is the proof.
+    decode_unix_cmsgs(buf, &mut meta);
+    if let Some(t) = meta.kernel_rx_time {
+      // If a stamp was produced it must be a real `SystemTime` (no panic in
+      // `duration_since` either); the exact value is unspecified for garbage
+      // input, we only require well-definedness.
+      let _ = t.duration_since(std::time::UNIX_EPOCH);
+    }
+  }
+
+  #[test]
+  fn recv_meta_default_is_safe_and_unspecified() {
+    let m = RecvMeta::empty(([127, 0, 0, 1], 5353).into());
+    assert!(m.local_ip.is_unspecified());
+    assert_eq!(m.interface_index, 0);
+    assert!(m.hop_limit.is_none());
+    assert!(m.kernel_rx_time.is_none());
+  }
+
+  /// Direct proof that the cmsg recv path delivers PKTINFO over loopback.
+  /// Higher layers (Endpoint, Service, Query) cover this indirectly, but
+  /// keeping the raw round-trip here as a unit test pins the low-level
+  /// pathway in isolation.
+  #[compio::test]
+  async fn raw_loopback_round_trip_carries_pktinfo_local_ip() {
+    use core::net::{Ipv4Addr, SocketAddr};
+    use mdns_udp::{MulticastOptionsV4, try_bind_v4, try_join_v4};
+    use std::time::Duration;
+
+    fn loopback_index() -> Option<u32> {
+      let ifs = getifs::interfaces().ok()?;
+      ifs
+        .iter()
+        .find(|i| {
+          i.flags().contains(getifs::Flags::LOOPBACK) && i.flags().contains(getifs::Flags::UP)
+        })
+        .map(|i| i.index())
+    }
+
+    let idx = match loopback_index() {
+      Some(i) => i,
+      None => {
+        eprintln!("skip: no loopback iface");
+        return;
+      }
+    };
+    let s1 = match try_bind_v4(MulticastOptionsV4::new(idx)) {
+      Ok(s) => s,
+      Err(e) => {
+        eprintln!("skip: bind: {e:?}");
+        return;
+      }
+    };
+    try_join_v4(&s1, idx).ok();
+    s1.set_nonblocking(true).unwrap();
+    let s2 = try_bind_v4(MulticastOptionsV4::new(idx)).unwrap();
+    try_join_v4(&s2, idx).ok();
+    s2.set_nonblocking(true).unwrap();
+    let sock1 = Socket::from_std(s1).await.unwrap();
+    let sock2 = Socket::from_std(s2).await.unwrap();
+    let payload = b"compio mdns hello";
+    let dst: SocketAddr = (Ipv4Addr::new(224, 0, 0, 251), 5353).into();
+    sock1.send_to(payload, dst, None).await.unwrap();
+    let (data, meta) = compio::time::timeout(Duration::from_secs(2), sock2.recv(2048))
+      .await
+      .expect("recv timed out")
+      .unwrap();
+    assert_eq!(&data[..payload.len()], payload);
+    // local_ip and interface_index are populated from PKTINFO on Linux/macOS;
+    // soft-assert because some loopback configs deliver UNSPECIFIED.
+    if meta.local_ip.is_unspecified() {
+      eprintln!("note: PKTINFO not delivered on this loopback config");
+    }
+  }
+}

--- a/mdns-compio/tests/loopback.rs
+++ b/mdns-compio/tests/loopback.rs
@@ -1,0 +1,787 @@
+//! End-to-end loopback tests for the compio driver.
+#![cfg(any(unix, windows))]
+#![allow(clippy::unwrap_used)]
+
+use std::time::Duration;
+
+fn super_loopback_index() -> Option<u32> {
+  let ifs = getifs::interfaces().ok()?;
+  ifs
+    .iter()
+    .find(|i| i.flags().contains(getifs::Flags::LOOPBACK) && i.flags().contains(getifs::Flags::UP))
+    .map(|i| i.index())
+}
+
+#[compio::test]
+async fn endpoint_server_constructs_and_drops_cleanly() {
+  use mdns_compio::{Endpoint, ServerOptions};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let opts = ServerOptions::default()
+    .with_interface_index(Some(idx))
+    .with_ipv6(false);
+  let ep = match Endpoint::server(opts).await {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("skip: {e:?}");
+      return;
+    }
+  };
+  drop(ep);
+}
+
+#[compio::test]
+async fn register_service_handle_is_returned() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("skip: {e:?}");
+      return;
+    }
+  };
+  let stype = Name::try_from_str("_t._tcp.local.").unwrap();
+  let inst = Name::try_from_str("R._t._tcp.local.").unwrap();
+  let host = Name::try_from_str("r.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let svc = ep.register_service(ServiceSpec::new(recs)).await.unwrap();
+  drop(svc);
+}
+
+#[compio::test]
+async fn start_query_returns_handle_and_next_terminates_on_timeout() {
+  use mdns_compio::{Endpoint, Name, QueryEvent, QuerySpec, ServerOptions};
+  use mdns_proto::wire::ResourceType;
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let spec = QuerySpec::new(
+    Name::try_from_str("_nx._tcp.local.").unwrap(),
+    ResourceType::Ptr,
+  )
+  .with_timeout(Duration::from_millis(500));
+  let q = ep.start_query(spec).await.unwrap();
+  let mut saw_terminal = false;
+  while let Some(ev) = q.next().await {
+    if matches!(ev, QueryEvent::Terminal(_)) {
+      saw_terminal = true;
+      break;
+    }
+  }
+  assert!(saw_terminal);
+}
+
+#[compio::test]
+async fn responder_reaches_established_on_loopback() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec, ServiceUpdate};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let stype = Name::try_from_str("_resp._tcp.local.").unwrap();
+  let inst = Name::try_from_str("R._resp._tcp.local.").unwrap();
+  let host = Name::try_from_str("r.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let svc = ep.register_service(ServiceSpec::new(recs)).await.unwrap();
+
+  let mut saw_established = false;
+  let _ = compio::time::timeout(std::time::Duration::from_secs(3), async {
+    while let Some(u) = svc.next().await {
+      if matches!(u, ServiceUpdate::Established) {
+        saw_established = true;
+        break;
+      }
+    }
+  })
+  .await;
+
+  if !saw_established {
+    eprintln!("note: did not observe Established within 3s — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn responder_to_querier_loopback_ptr() {
+  use mdns_compio::{
+    Endpoint, Name, QueryEvent, QuerySpec, ServerOptions, ServiceRecords, ServiceSpec,
+  };
+  use mdns_proto::wire::ResourceType;
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_ptr._tcp.local.").unwrap();
+  let inst = Name::try_from_str("P._ptr._tcp.local.").unwrap();
+  let host = Name::try_from_str("p.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype.clone(), inst, host, 9999, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let the responder finish probing + announcing before the querier asks.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let q = querier
+    .start_query(QuerySpec::new(stype, ResourceType::Ptr).with_timeout(Duration::from_secs(2)))
+    .await
+    .unwrap();
+
+  let mut got_ptr = false;
+  let _ = compio::time::timeout(Duration::from_secs(3), async {
+    while let Some(ev) = q.next().await {
+      match ev {
+        QueryEvent::Answer(a) => {
+          if a.rtype() == ResourceType::Ptr {
+            got_ptr = true;
+            break;
+          }
+        }
+        QueryEvent::Terminal(_) => break,
+      }
+    }
+  })
+  .await;
+
+  if !got_ptr {
+    eprintln!("note: no PTR within window — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn browse_returns_registered_instance() {
+  use mdns_compio::{Endpoint, Name, QueryParam, ServerOptions, ServiceRecords, ServiceSpec};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_b._tcp.local.").unwrap();
+  let inst = Name::try_from_str("B._b._tcp.local.").unwrap();
+  let host = Name::try_from_str("b.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype.clone(), inst, host, 7777, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let the responder finish probing + announcing before the querier browses.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let lookup = querier
+    .browse(QueryParam::new(stype).with_timeout(Duration::from_secs(2)))
+    .await
+    .unwrap();
+  let entry = compio::time::timeout(Duration::from_secs(3), async {
+    let mut l = lookup;
+    l.next().await
+  })
+  .await
+  .ok()
+  .flatten();
+
+  if let Some(e) = entry {
+    assert_eq!(e.port(), 7777);
+  } else {
+    eprintln!("note: no entry — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn responder_to_querier_loopback_srv() {
+  use mdns_compio::{
+    Endpoint, Name, QueryEvent, QuerySpec, ServerOptions, ServiceRecords, ServiceSpec,
+  };
+  use mdns_proto::wire::ResourceType;
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_srv._tcp.local.").unwrap();
+  let inst = Name::try_from_str("S._srv._tcp.local.").unwrap();
+  let host = Name::try_from_str("s.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst.clone(), host, 5555, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let the responder finish probing + announcing before the querier asks.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let q = querier
+    .start_query(QuerySpec::new(inst, ResourceType::Srv).with_timeout(Duration::from_secs(2)))
+    .await
+    .unwrap();
+
+  let mut got_srv = false;
+  let _ = compio::time::timeout(Duration::from_secs(3), async {
+    while let Some(ev) = q.next().await {
+      match ev {
+        QueryEvent::Answer(a) => {
+          if a.rtype() == ResourceType::Srv {
+            got_srv = true;
+            break;
+          }
+        }
+        QueryEvent::Terminal(_) => break,
+      }
+    }
+  })
+  .await;
+
+  if !got_srv {
+    eprintln!("note: no SRV within window — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn responder_to_querier_loopback_txt() {
+  use mdns_compio::{
+    Endpoint, Name, QueryEvent, QuerySpec, ServerOptions, ServiceRecords, ServiceSpec,
+  };
+  use mdns_proto::wire::ResourceType;
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_txt._tcp.local.").unwrap();
+  let inst = Name::try_from_str("T._txt._tcp.local.").unwrap();
+  let host = Name::try_from_str("t.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst.clone(), host, 6666, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let the responder finish probing + announcing before the querier asks.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let q = querier
+    .start_query(QuerySpec::new(inst, ResourceType::Txt).with_timeout(Duration::from_secs(2)))
+    .await
+    .unwrap();
+
+  let mut got_txt = false;
+  let _ = compio::time::timeout(Duration::from_secs(3), async {
+    while let Some(ev) = q.next().await {
+      match ev {
+        QueryEvent::Answer(a) => {
+          if a.rtype() == ResourceType::Txt {
+            got_txt = true;
+            break;
+          }
+        }
+        QueryEvent::Terminal(_) => break,
+      }
+    }
+  })
+  .await;
+
+  if !got_txt {
+    eprintln!("note: no TXT within window — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn responder_to_querier_loopback_a() {
+  use mdns_compio::{
+    Endpoint, Name, QueryEvent, QuerySpec, ServerOptions, ServiceRecords, ServiceSpec,
+  };
+  use mdns_proto::wire::ResourceType;
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_a._tcp.local.").unwrap();
+  let inst = Name::try_from_str("A._a._tcp.local.").unwrap();
+  let host = Name::try_from_str("a.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst, host.clone(), 4444, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let the responder finish probing + announcing before the querier asks.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let q = querier
+    .start_query(QuerySpec::new(host, ResourceType::A).with_timeout(Duration::from_secs(2)))
+    .await
+    .unwrap();
+
+  let mut got_a = false;
+  let _ = compio::time::timeout(Duration::from_secs(3), async {
+    while let Some(ev) = q.next().await {
+      match ev {
+        QueryEvent::Answer(a) => {
+          if a.rtype() == ResourceType::A {
+            got_a = true;
+            break;
+          }
+        }
+        QueryEvent::Terminal(_) => break,
+      }
+    }
+  })
+  .await;
+
+  if !got_a {
+    eprintln!("note: no A within window — env may not loop multicast");
+  }
+}
+
+#[compio::test]
+async fn resolve_host_returns_addresses() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec};
+  use std::net::IpAddr;
+
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_rh._tcp.local.").unwrap();
+  let inst = Name::try_from_str("RH._rh._tcp.local.").unwrap();
+  let host = Name::try_from_str("rh.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst, host.clone(), 3333, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  // Let probe + announce settle before issuing queries.
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let addrs = match querier.resolve_host(host, Duration::from_secs(2)).await {
+    Ok(a) => a,
+    Err(e) => {
+      eprintln!("note: resolve_host failed: {e:?}");
+      return;
+    }
+  };
+
+  if addrs.is_empty() {
+    eprintln!("note: resolve_host returned no addresses — env may not loop multicast");
+    return;
+  }
+
+  assert!(
+    addrs.contains(&IpAddr::V4(core::net::Ipv4Addr::new(127, 0, 0, 1))),
+    "expected 127.0.0.1 in {addrs:?}"
+  );
+}
+
+/// RFC 6762 §10.1: dropping a registered service must release the
+/// proto-layer route slot (so the same instance name can be re-registered
+/// immediately) AND queue the TTL=0 goodbye burst — the regression Service
+/// Drop used to skip, leaking a slot per drop until endpoint shutdown.
+///
+/// We can't directly observe the goodbye datagrams on the wire from a
+/// caller-level test (multicast loopback may not echo to the same process
+/// in every environment), so the assertion is the proto-side one: an
+/// immediate re-register of the same instance name on the same endpoint
+/// must succeed. Before the fix this returned `NameAlreadyRegistered`
+/// because the proto route was never released on Drop.
+#[compio::test]
+async fn dropping_service_releases_proto_slot_for_reregister() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("skip: {e:?}");
+      return;
+    }
+  };
+  let stype = Name::try_from_str("_gb._tcp.local.").unwrap();
+  let inst = Name::try_from_str("GB._gb._tcp.local.").unwrap();
+  let host = Name::try_from_str("gb.local.").unwrap();
+  let mk = || {
+    let mut r = ServiceRecords::new(stype.clone(), inst.clone(), host.clone(), 1234, 120);
+    r.add_a([127, 0, 0, 1].into());
+    ServiceSpec::new(r)
+  };
+  let svc = ep.register_service(mk()).await.unwrap();
+  // Give the driver one loop iteration to pick up the registration before
+  // dropping it.
+  compio::time::sleep(Duration::from_millis(50)).await;
+  drop(svc);
+  // Withdrawal is DRIVER-OWNED: `Service::drop` only flags the service
+  // cancelled (so a send in flight when the handle dropped can latch before the
+  // §10.1 goodbye is encoded); the driver's post-pump sweep then frees the
+  // proto route slot. Yield so that sweep runs before we re-register the same
+  // instance name — otherwise the slot is still held and re-registration would
+  // hit NameAlreadyRegistered.
+  compio::time::sleep(Duration::from_millis(100)).await;
+  let svc2 = ep
+    .register_service(mk())
+    .await
+    .expect("re-register after drop must succeed once the driver sweep frees the slot");
+  drop(svc2);
+}
+
+/// Dropping the Endpoint AND its last Service together must not hang the driver
+/// task: the spawned driver observes `Rc::strong_count == 1` on its pre-park
+/// settle step and exits, flushing the §10.1 goodbye, even though the drops'
+/// `notify` wakes may have been lost (no listener armed mid-loop). Regression
+/// for the codex R5 lost-notify shutdown stall: before the redesign the driver
+/// could park forever after the last handle dropped during a send. The test
+/// passes by simply completing — a hung driver would not deadlock the test (the
+/// task is detached) but this exercises the clean-teardown path without panic,
+/// and the bounded sleep lets the driver run its shutdown drain.
+#[compio::test]
+async fn dropping_endpoint_and_service_shuts_down_cleanly() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec};
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("skip: {e:?}");
+      return;
+    }
+  };
+  let stype = Name::try_from_str("_sd._tcp.local.").unwrap();
+  let inst = Name::try_from_str("SD._sd._tcp.local.").unwrap();
+  let host = Name::try_from_str("sd.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst, host, 1234, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let svc = ep.register_service(ServiceSpec::new(recs)).await.unwrap();
+  // Let the service probe/announce so a real goodbye is owed at withdrawal.
+  compio::time::sleep(Duration::from_millis(800)).await;
+
+  // Drop BOTH handles: this releases the last external `Rc<EndpointInner>` so
+  // the driver's next pre-park settle sees `strong_count == 1` and runs the
+  // shutdown goodbye flush before exiting — regardless of whether either drop's
+  // `notify` reached a listener.
+  drop(svc);
+  drop(ep);
+
+  // Give the detached driver time to settle + flush + exit. Reaching here
+  // without a panic is the assertion; the redesign guarantees the driver does
+  // not park indefinitely after the last handle is gone.
+  compio::time::sleep(Duration::from_millis(300)).await;
+}
+
+#[compio::test]
+async fn resolve_instance_returns_entry() {
+  use mdns_compio::{Endpoint, Name, ServerOptions, ServiceRecords, ServiceSpec};
+
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let responder = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+  let querier = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(_) => return,
+  };
+
+  let stype = Name::try_from_str("_ri._tcp.local.").unwrap();
+  let inst = Name::try_from_str("RI._ri._tcp.local.").unwrap();
+  let host = Name::try_from_str("ri.local.").unwrap();
+  let mut recs = ServiceRecords::new(stype, inst.clone(), host, 2222, 120);
+  recs.add_a([127, 0, 0, 1].into());
+  let _svc = responder
+    .register_service(ServiceSpec::new(recs))
+    .await
+    .unwrap();
+
+  compio::time::sleep(Duration::from_millis(1300)).await;
+
+  let entry = match querier.resolve_instance(inst, Duration::from_secs(3)).await {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("note: resolve_instance failed: {e:?}");
+      return;
+    }
+  };
+
+  let entry = match entry {
+    Some(e) => e,
+    None => {
+      eprintln!("note: resolve_instance returned None — env may not loop multicast");
+      return;
+    }
+  };
+
+  assert_eq!(entry.port(), 2222, "wrong port");
+  assert!(
+    entry.host().as_str().eq_ignore_ascii_case("ri.local."),
+    "wrong host: {}",
+    entry.host()
+  );
+  assert!(
+    !entry.ipv4_addresses().is_empty() || !entry.ipv6_addresses().is_empty(),
+    "entry has no addresses: v4={:?} v6={:?}",
+    entry.ipv4_addresses(),
+    entry.ipv6_addresses()
+  );
+}
+
+/// codex R9 liveness regression: a query started with a default `QuerySpec`
+/// (timeout `None`) must make progress — its first question gets transmitted and
+/// it can be cancelled cleanly — WITHOUT any other endpoint activity to wake the
+/// driver. Before the `dirty`-flag invariant, `start_query`'s `notify` could be
+/// lost across the driver's send-awaits and, with no timeout deadline and no
+/// other traffic, the driver would park forever and `Query::next` would hang.
+/// The bounded timeout turns a regression into a failure rather than a hung
+/// suite: we only need the driver to be ALIVE and responsive (the query need not
+/// receive an answer on loopback — reaching the drop + clean cancel is the
+/// liveness proof).
+#[compio::test]
+async fn timeoutless_query_makes_progress_without_other_traffic() {
+  use mdns_compio::{Endpoint, Name, QuerySpec, ServerOptions};
+  use mdns_proto::wire::ResourceType;
+
+  let idx = match super_loopback_index() {
+    Some(i) => i,
+    None => return,
+  };
+  let ep = match Endpoint::server(
+    ServerOptions::default()
+      .with_interface_index(Some(idx))
+      .with_ipv6(false),
+  )
+  .await
+  {
+    Ok(e) => e,
+    Err(e) => {
+      eprintln!("skip: {e:?}");
+      return;
+    }
+  };
+
+  // Default QuerySpec → timeout: None. The ONLY thing that schedules a deadline
+  // is the first transmit actually being pumped; if start_query's wake is lost
+  // the driver has nothing to wake on.
+  let qname = Name::try_from_str("liveness-probe.local.").unwrap();
+  let q = ep
+    .start_query(QuerySpec::new(qname, ResourceType::A))
+    .await
+    .expect("start_query must succeed");
+
+  // The driver must be alive enough to pump the question + keep ticking. Give it
+  // a brief window with NO other traffic; then prove the whole stack is still
+  // responsive by driving a bounded next() (it returns on the proto's own retry
+  // cadence or stays pending — either way the runtime is not deadlocked).
+  let _ = compio::time::timeout(Duration::from_millis(500), q.next()).await;
+
+  // Cleanly drop the query, then confirm the endpoint is still responsive by
+  // starting + dropping another query within a bounded window — a parked-forever
+  // driver would not service this second registration's wake either.
+  drop(q);
+  let q2 = compio::time::timeout(
+    Duration::from_secs(2),
+    ep.start_query(QuerySpec::new(
+      Name::try_from_str("liveness-probe-2.local.").unwrap(),
+      ResourceType::A,
+    )),
+  )
+  .await
+  .expect("driver must still service start_query (not parked forever)")
+  .expect("second start_query must succeed");
+  drop(q2);
+}

--- a/mdns-reactor/src/driver.rs
+++ b/mdns-reactor/src/driver.rs
@@ -1262,9 +1262,11 @@ fn packet_is_response(data: &[u8]) -> bool {
 /// single link, so a link-local source counts as on-link ONLY when it arrived
 /// on the bound interface. When `recv_iface` is `0` (provenance unavailable)
 /// we cannot scope it and accept it (degraded) rather than drop legitimate
-/// link-local discovery. Loopback is always on-link. When the subnet list is
-/// empty (enumeration failed) we likewise accept, so a discovery never breaks
-/// just because interface lookup failed.
+/// link-local discovery. Loopback is always on-link. A global (routable)
+/// source is accepted only when it matches a cached local subnet; with no
+/// match — including when no subnets were enumerated — it is dropped as
+/// off-link (fail-closed per §11), so a global sender is never admitted
+/// without positive on-link evidence.
 fn src_on_local_link(
   local_subnets: &[(IpAddr, u8)],
   bound_iface: u32,
@@ -1284,9 +1286,9 @@ fn src_on_local_link(
     // (degraded) rather than drop.
     return recv_iface == 0 || recv_iface == bound_iface;
   }
-  if local_subnets.is_empty() {
-    return true; // couldn't enumerate — don't wrongly drop
-  }
+  // Global (routable) source: admit only with positive on-link evidence. An
+  // empty `local_subnets` makes `any` return `false`, so a global source is
+  // dropped as off-link (fail-closed per §11) when nothing was enumerated.
   local_subnets
     .iter()
     .any(|&(net, prefix)| addr_in_subnet(net, prefix, src))
@@ -2451,12 +2453,33 @@ mod tests {
       BOUND,
       IpAddr::V4(Ipv4Addr::LOCALHOST)
     ));
-    // No enumerated subnets → conservatively accept (can't determine).
-    assert!(src_on_local_link(
+    // §11 fail-closed: a global source with no enumerated subnets has no
+    // on-link evidence and is dropped (was previously fail-open).
+    assert!(!src_on_local_link(
       &[],
       BOUND,
       BOUND,
       IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
+    ));
+    assert!(!src_on_local_link(
+      &[],
+      BOUND,
+      BOUND,
+      IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
+    ));
+    // A global source inside a cached /8 is on-link; outside it is dropped.
+    let wide = vec![(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8u8)];
+    assert!(src_on_local_link(
+      &wide,
+      BOUND,
+      BOUND,
+      IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))
+    ));
+    assert!(!src_on_local_link(
+      &wide,
+      BOUND,
+      BOUND,
+      IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
     ));
   }
 
@@ -2486,8 +2509,8 @@ mod tests {
   fn collect_local_subnets_rejects_zero_index() {
     // the fallback is scoped to the BOUND interface. Index 0 is
     // "no interface" — it must NOT enumerate every NIC, so the result is
-    // empty (which makes src_on_local_link conservatively fail open rather
-    // than treat another NIC's subnet as on-link).
+    // empty (which makes src_on_local_link fail closed for a global source
+    // rather than treat another NIC's subnet as on-link).
     assert!(collect_local_subnets(0).is_empty());
   }
 

--- a/mdns-udp/src/multicast.rs
+++ b/mdns-udp/src/multicast.rs
@@ -492,7 +492,8 @@ pub fn recv_with_meta(
   // to hand `recvmsg` a pointer to fill; recvmsg writes a valid sockaddr within
   // `msg_namelen` before we read it back via `SockAddr::new`.
   #[allow(unsafe_code)]
-  let storage_ptr = unsafe { storage.view_as::<libc::sockaddr_storage>() } as *mut libc::sockaddr_storage;
+  let storage_ptr =
+    unsafe { storage.view_as::<libc::sockaddr_storage>() } as *mut libc::sockaddr_storage;
   msg.msg_name = storage_ptr.cast();
   msg.msg_namelen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
   msg.msg_iov = core::ptr::addr_of_mut!(iov);
@@ -742,7 +743,6 @@ fn parse_rx_time(cmsgs: &[u8]) -> Option<SystemTime> {
 fn parse_rx_time(_cmsgs: &[u8]) -> Option<SystemTime> {
   None
 }
-
 
 /// One parsed cmsg header + data slice.
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Adds **`mdns-compio`**, a standalone compio-native async mDNS crate — responder, querier, and DNS-SD discovery — designed for compio's thread-per-core, completion-based runtime. Layered on `mdns-proto` (sans-I/O state machines) and `mdns-udp` (multicast socket helpers); **independent of `mdns-reactor`** (no code reuse — the architecture is built for thread-per-core, not ported from the multi-threaded reactor).

## Design

- One cloneable `Endpoint` over `Rc<EndpointInner>`; a single spawned driver future owns the compio `UdpSocket`(s) and runs `select! { recv_v4, recv_v6, timer, notify }`.
- **`!Send` throughout** — no `Arc`/`Mutex`/atomics/MPSC; shared state is `Rc<RefCell<State>>`; **no `RefCell` borrow is held across `.await`**.
- In-crate cmsg codec (`#[repr(align(8))]` control buffers, unaligned payload reads); `RecvMeta` carries `IP_PKTINFO`, TTL/hop-limit, and `SCM_TIMESTAMP[NS]`, gated per-target by a `build.rs` capability matrix mirroring `mdns-udp`.
- **Driver-liveness invariant:** every handle op that creates driver work calls `EndpointInner::mark_dirty`; the driver consumes that flag at the park boundary (after every awaitable pump, with no `.await` before the `select!` listener is armed) and never parks while it's set. A lost `event-listener` notify is therefore a latency optimization, never a liveness guarantee.

## API

`Endpoint::server`, `register_service`, `start_query`, `browse`, `lookup`, `resolve_host`, `resolve_instance`; types `Query`, `Service`, `Lookup`, `ServiceEntry`, `QueryParam`, `QueryEvent`, `ServerOptions`, plus `mdns-proto` re-exports. Mirrors `mdns-reactor`'s public surface so callers can switch runtimes with minimal churn.

## RFC 6762 / 6763

- §8 probe/announce through the transmit pump; §10.1 goodbye burst on withdrawal — driver-owned, safe against the drop-vs-in-flight-send race and last-handle shutdown.
- §11 on-link gate: TTL/hop-limit == 255 when delivered, else a source-address-on-local-subnet fallback that **fails closed** for global sources lacking on-link evidence.
- Dual-stack multicast fan-out to both groups (`224.0.0.251` + `ff02::fb`).
- DNS-SD `Resolver` aggregation (PTR → SRV/TXT → A/AAAA) with bounded/coalescing per-instance and per-host caps.

Also tightens the published `mdns-reactor` §11 source-address fallback to fail closed for parity with the new crate (`mdns-reactor/src/driver.rs`).

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-features --tests -- -D warnings` ✅
- `cargo test --workspace` ✅ — `mdns-compio` 60 lib + 14 loopback; full workspace green
- `cargo doc -p mdns-compio --all-features --no-deps` ✅
- **Codex adversarial review: APPROVE (R11, no material findings).** An 11-round loop drove out dual-stack multicast, §10.1 goodbye-delivery races, query answer-ordering under slab reuse, cmsg portability (`SO_*` vs `SCM_*` timestamp), service/query encode-failure stalls, and a recurring lost-wake liveness class (closed by the invariant above).

## Known follow-ups

- The auto-rename path (`Endpoint::handle_service_renamed` wiring) has no dedicated `mdns-compio` test — a two-endpoint name-conflict integration test would close it; the wiring mirrors `mdns-reactor`'s tested path and `mdns-proto`'s own routing test.
- Windows: cmsg recv metadata isn't plumbed (recv falls back to plain `recv_from`), so the §11 gate degrades to admit-all there. A native IOCP cmsg port is future work.
