### PR TITLE
perf: reduce clones via SmolStr discovery keys and Bytes rdata

### DIFF
--- a/hick-compio/Cargo.toml
+++ b/hick-compio/Cargo.toml
@@ -33,6 +33,7 @@ futures = { version = "0.3", default-features = false, features = ["std", "async
 event-listener = "5"
 getifs = "0.6"
 slab = "0.4"
+smol_str = "0.3"
 rand = "0.10"
 thiserror = "2"
 

--- a/hick-compio/src/discovery.rs
+++ b/hick-compio/src/discovery.rs
@@ -22,6 +22,7 @@ use mdns_proto::{
   Name, QuerySpec,
   wire::{A, AAAA, NameRef, Ptr, ResourceType, Srv, Txt},
 };
+use smol_str::SmolStr;
 
 use crate::{
   endpoint::Endpoint,
@@ -173,8 +174,12 @@ pub(crate) fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
 /// Case-fold a [`Name`] to its lookup key. DNS names are case-insensitive
 /// (RFC 6762 §16), so the lower-cased string form is the canonical key for
 /// the resolver's per-instance / per-host maps.
-pub(crate) fn fold(name: &Name) -> String {
-  name.as_str().to_ascii_lowercase()
+pub(crate) fn fold(name: &Name) -> SmolStr {
+  name
+    .as_str()
+    .chars()
+    .map(|c| c.to_ascii_lowercase())
+    .collect()
 }
 
 /// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
@@ -236,10 +241,10 @@ pub(crate) fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
 #[allow(clippy::upper_case_acronyms)] // `AAAA` mirrors the DNS record-type name
 pub(crate) enum Step {
   Ptr,
-  Srv(String),
-  Txt(String),
-  A(String),
-  AAAA(String),
+  Srv(SmolStr),
+  Txt(SmolStr),
+  A(SmolStr),
+  AAAA(SmolStr),
 }
 
 /// A follow-up query the driver should launch as a result of feeding the
@@ -275,7 +280,7 @@ pub(crate) struct HostAddrs {
 pub(crate) struct Builder {
   pub(crate) instance: Name,
   pub(crate) host: Option<Name>,
-  pub(crate) host_key: Option<String>,
+  pub(crate) host_key: Option<SmolStr>,
   /// Whether an SRV record has been seen. Tracked separately from `port`
   /// because `0` is a valid SRV port (the full `u16` range is parsed and the
   /// registration API does not reject it), so it cannot double as a sentinel.
@@ -322,9 +327,9 @@ impl Builder {
 /// Pure browse/resolve aggregation state machine — no I/O. The lookup driver
 /// feeds it parsed answers and launches the follow-up queries it requests.
 pub(crate) struct Resolver {
-  pub(crate) builders: HashMap<String, Builder>,
-  pub(crate) host_addrs: HashMap<String, HostAddrs>,
-  pub(crate) hosts_queried: HashSet<String>,
+  pub(crate) builders: HashMap<SmolStr, Builder>,
+  pub(crate) host_addrs: HashMap<SmolStr, HostAddrs>,
+  pub(crate) hosts_queried: HashSet<SmolStr>,
   pub(crate) ready: VecDeque<ServiceEntry>,
   /// Cap on distinct instances tracked.
   pub(crate) max_entries: usize,
@@ -450,7 +455,7 @@ impl Resolver {
   }
 
   pub(crate) fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
-    let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
+    let cache = self.host_addrs.entry(SmolStr::from(host_key)).or_default();
     match addr {
       IpAddr::V4(a) => {
         push_capped(&mut cache.ipv4, a);
@@ -459,7 +464,7 @@ impl Resolver {
         push_capped(&mut cache.ipv6, a);
       }
     }
-    let keys: Vec<String> = self
+    let keys: Vec<SmolStr> = self
       .builders
       .iter()
       .filter(|(_, b)| b.host_key.as_deref() == Some(host_key))

--- a/hick-reactor/src/discovery.rs
+++ b/hick-reactor/src/discovery.rs
@@ -45,6 +45,7 @@ use mdns_proto::{
   Name, QuerySpec,
   wire::{A, AAAA, NameRef, Ptr, ResourceType, Srv, Txt},
 };
+use smol_str::SmolStr;
 
 use crate::{
   Endpoint, QueryEvent,
@@ -189,10 +190,10 @@ impl QueryParam {
 #[allow(clippy::upper_case_acronyms)] // `AAAA` mirrors the DNS record-type name
 enum Step {
   Ptr,
-  Srv(String),
-  Txt(String),
-  A(String),
-  AAAA(String),
+  Srv(SmolStr),
+  Txt(SmolStr),
+  A(SmolStr),
+  AAAA(SmolStr),
 }
 
 /// One answer, tagged with the resolve step that produced it.
@@ -225,7 +226,7 @@ impl Start {
 struct Builder {
   instance: Name,
   host: Option<Name>,
-  host_key: Option<String>,
+  host_key: Option<SmolStr>,
   /// Whether an SRV record has been seen. Tracked separately from `port`
   /// because `0` is a valid SRV port (the full `u16` range is parsed and the
   /// registration API does not reject it), so it cannot double as a sentinel.
@@ -281,9 +282,9 @@ struct HostAddrs {
 /// Pure browse/resolve aggregation state machine — no I/O. The [`LookupDriver`]
 /// feeds it parsed answers and launches the follow-up queries it requests.
 struct Resolver {
-  builders: HashMap<String, Builder>,
-  host_addrs: HashMap<String, HostAddrs>,
-  hosts_queried: HashSet<String>,
+  builders: HashMap<SmolStr, Builder>,
+  host_addrs: HashMap<SmolStr, HostAddrs>,
+  hosts_queried: HashSet<SmolStr>,
   ready: VecDeque<ServiceEntry>,
   /// Cap on distinct instances tracked.
   max_entries: usize,
@@ -413,12 +414,12 @@ impl Resolver {
   /// Only called for a host we actually launched A/AAAA queries for (a step key
   /// from a query we started), so `host_addrs` stays bounded by `hosts_queried`.
   fn on_addr(&mut self, host_key: &str, addr: IpAddr) {
-    let cache = self.host_addrs.entry(host_key.to_owned()).or_default();
+    let cache = self.host_addrs.entry(SmolStr::from(host_key)).or_default();
     match addr {
       IpAddr::V4(a) => push_capped(&mut cache.ipv4, a),
       IpAddr::V6(a) => push_capped(&mut cache.ipv6, a),
     };
-    let keys: Vec<String> = self
+    let keys: Vec<SmolStr> = self
       .builders
       .iter()
       .filter(|(_, b)| b.host_key.as_deref() == Some(host_key))
@@ -906,8 +907,12 @@ fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
 
 /// Case-fold a name to its lookup key (DNS names are case-insensitive,
 /// RFC 6762 §16).
-fn fold(name: &Name) -> String {
-  name.as_str().to_ascii_lowercase()
+fn fold(name: &Name) -> SmolStr {
+  name
+    .as_str()
+    .chars()
+    .map(|c| c.to_ascii_lowercase())
+    .collect()
 }
 
 /// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as

--- a/mdns-proto/Cargo.toml
+++ b/mdns-proto/Cargo.toml
@@ -25,8 +25,8 @@ categories = ["network-programming", "no-std", "embedded"]
 # `Name` needs string/collection backing.
 [features]
 default = ["std", "slab"]
-std = ["smol_str/std", "rand/std", "thiserror/std"]
-alloc = ["dep:smol_str", "dep:rand"]
+std = ["smol_str/std", "rand/std", "thiserror/std", "bytes/std"]
+alloc = ["dep:smol_str", "dep:rand", "dep:bytes"]
 slab = ["dep:slab"]
 heapless = ["dep:heapless"]
 tracing = ["hick-trace/tracing"]
@@ -48,6 +48,7 @@ thiserror = { version = "2.0", default-features = false }
 derive_more = { version = "2", default-features = false, features = ["display", "from", "is_variant", "unwrap", "try_unwrap"] }
 rand_core = { version = "0.10", default-features = false }
 smol_str = { version = "0.3", default-features = false, optional = true }
+bytes = { version = "1", default-features = false, optional = true }
 rand = { version = "0.10", default-features = false, features = ["std_rng"], optional = true }
 slab = { version = "0.4", default-features = false, optional = true }
 heapless = { version = "0.9", optional = true }

--- a/mdns-proto/src/cache.rs
+++ b/mdns-proto/src/cache.rs
@@ -4,6 +4,9 @@
 use core::time::Duration;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
+use bytes::Bytes;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::Instant;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::Name;
@@ -25,7 +28,7 @@ pub struct CacheEntry<I: Instant> {
   /// but class != IN could corrupt the cache across protocol identity
   /// boundaries.
   rclass: ResourceClass,
-  rdata: std::vec::Vec<u8>,
+  rdata: Bytes,
   expires_at: I,
   /// When this record was last received / refreshed.  used to
   /// implement the RFC 6762 §10.2 "1-second grace" on cache-flush —
@@ -44,7 +47,7 @@ impl<I: Instant> CacheEntry<I> {
     name: Name,
     rtype: ResourceType,
     rclass: ResourceClass,
-    rdata: std::vec::Vec<u8>,
+    rdata: Bytes,
     expires_at: I,
     received_at: I,
   ) -> Self {
@@ -79,7 +82,7 @@ impl<I: Instant> CacheEntry<I> {
   /// The record's raw rdata bytes.
   #[inline(always)]
   pub fn rdata_slice(&self) -> &[u8] {
-    &self.rdata
+    self.rdata.as_ref()
   }
 
   /// Absolute expiration deadline.
@@ -206,7 +209,7 @@ where
     name: Name,
     rtype: ResourceType,
     rclass: ResourceClass,
-    rdata: std::vec::Vec<u8>,
+    rdata: impl Into<Bytes>,
     ttl: Duration,
     now: I,
     cache_flush: bool,
@@ -221,6 +224,7 @@ where
       // here (the cache is empty by construction), so just bail.
       return Ok(None);
     }
+    let rdata: Bytes = rdata.into();
     // TTL=0 → goodbye (RFC 6762 §10.1). Do NOT delete immediately: shorten the
     // matching entry to expire in ONE SECOND. This gives any responder still
     // using the record a window to rescue it (a positive-TTL re-announce before
@@ -235,7 +239,7 @@ where
           if entry.rtype() == rtype
             && entry.rclass() == rclass
             && entry.name().as_str() == name.as_str()
-            && entry.rdata_slice() == rdata.as_slice()
+            && entry.rdata_slice() == rdata.as_ref()
           {
             victim = Some(key);
             break;
@@ -283,7 +287,7 @@ where
             Some(d) => d < Duration::from_secs(1),
             None => true, // received_at in the future — treat as recent
           };
-          if recent || entry.rdata_slice() == rdata.as_slice() {
+          if recent || entry.rdata_slice() == rdata.as_ref() {
             continue;
           }
           // Only clamp if it would shorten the deadline.
@@ -309,7 +313,7 @@ where
       if entry.rtype() == rtype
         && entry.rclass() == rclass
         && entry.name().as_str() == name.as_str()
-        && entry.rdata_slice() == rdata.as_slice()
+        && entry.rdata_slice() == rdata.as_ref()
       {
         update_key = Some(key);
         break;

--- a/mdns-proto/src/endpoint.rs
+++ b/mdns-proto/src/endpoint.rs
@@ -1811,7 +1811,7 @@ where
         // the stored and incoming bytes makes those comparisons encoding- and
         // case-independent (the cache never surfaces rdata for display). A
         // malformed / over-length name-bearing record is dropped, not cached.
-        let rdata: std::vec::Vec<u8> = match r.canonical_rdata_folded() {
+        let rdata = match r.canonical_rdata_folded() {
           Ok(v) => v,
           Err(_) => continue,
         };

--- a/mdns-proto/src/query/mod.rs
+++ b/mdns-proto/src/query/mod.rs
@@ -11,6 +11,8 @@ use crate::{
   transmit::Transmit,
   wire::{DEFAULT_COMPRESSION_TABLE, Header, MessageBuilder, ResourceClass, ResourceType},
 };
+#[cfg(any(feature = "alloc", feature = "std"))]
+use bytes::Bytes;
 
 /// Maximum retries before giving up.
 const MAX_RETRIES: u32 = 8;
@@ -29,7 +31,7 @@ const DEFAULT_MAX_ANSWERS: usize = 256;
 pub struct CollectedAnswer {
   rtype: ResourceType,
   rclass: ResourceClass,
-  rdata: std::vec::Vec<u8>,
+  rdata: Bytes,
   /// the case-FOLDED identity form of `rdata` (PTR/SRV/NSEC/CNAME
   /// names lowercased) used for dedup, cap accounting, and mailbox coalescing —
   /// while `rdata` keeps the original case for display. Two answers that are
@@ -41,7 +43,7 @@ pub struct CollectedAnswer {
   /// common case: A/AAAA/TXT/unknown rdata, or a name already lowercase), so we
   /// store ONLY one buffer — folding a large TXT/unknown flood does not double
   /// per-answer memory. [`Self::rdata_key`] resolves `None` to `rdata`.
-  rdata_key: Option<std::vec::Vec<u8>>,
+  rdata_key: Option<Bytes>,
   /// Monotonically increasing insertion sequence number within a single Query.
   /// Used to identify the oldest entry for FIFO eviction.
   seq: u64,
@@ -60,13 +62,13 @@ impl CollectedAnswer {
   pub fn from_parts(
     rtype: ResourceType,
     rclass: ResourceClass,
-    rdata: std::vec::Vec<u8>,
+    rdata: impl Into<Bytes>,
     seq: u64,
   ) -> Self {
     Self {
       rtype,
       rclass,
-      rdata,
+      rdata: rdata.into(),
       rdata_key: None,
       seq,
     }
@@ -88,7 +90,7 @@ impl CollectedAnswer {
   /// display). For identity/dedup comparisons use [`Self::rdata_key`].
   #[inline(always)]
   pub fn rdata_slice(&self) -> &[u8] {
-    &self.rdata
+    self.rdata.as_ref()
   }
 
   /// The case-FOLDED identity form of the rdata. Equal for two
@@ -98,7 +100,7 @@ impl CollectedAnswer {
   /// to `rdata` when the folded form is identical (no separate buffer stored).
   #[inline(always)]
   pub fn rdata_key(&self) -> &[u8] {
-    self.rdata_key.as_deref().unwrap_or(&self.rdata)
+    self.rdata_key.as_deref().unwrap_or(self.rdata.as_ref())
   }
 
   /// Insertion sequence number (monotonically increasing per-Query).
@@ -336,7 +338,7 @@ where
         // and names already lowercase — the folded form equals `owned`, so we
         // store None and avoid doubling memory under a large-rdata flood.
         let rdata_key = if folded == owned { None } else { Some(folded) };
-        let key: &[u8] = rdata_key.as_deref().unwrap_or(&owned);
+        let key: &[u8] = rdata_key.as_deref().unwrap_or(owned.as_ref());
 
         // Dedupe: skip if a matching (rtype, rclass, folded-rdata) already in.
         for (_, existing) in self.answers.iter() {

--- a/mdns-proto/src/records.rs
+++ b/mdns-proto/src/records.rs
@@ -12,6 +12,8 @@ use std::vec::Vec;
 
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::Name;
+#[cfg(any(feature = "alloc", feature = "std"))]
+use bytes::Bytes;
 
 /// Records advertised by a single registered service.
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -38,7 +40,7 @@ pub struct ServiceRecords {
   /// classified as self.  Set via [`Self::add_aaaa_scoped`].  Always the
   /// same length as `aaaa_addrs`.
   aaaa_scopes: Vec<u32>,
-  txt: Vec<Vec<u8>>,
+  txt: Vec<Bytes>,
   /// RFC 6763 §7.1 subtype browse names, e.g. `_printer._sub._ipp._tcp.local.`.
   /// Each is the full `<sub>._sub.<service_type>` name (derived from
   /// `service_type` at [`Self::add_subtype`] time, so it survives an instance
@@ -141,7 +143,7 @@ impl ServiceRecords {
 
   /// TXT segments as an iterator over byte slices.
   pub fn txt_segments(&self) -> impl Iterator<Item = &[u8]> {
-    self.txt.iter().map(Vec::as_slice)
+    self.txt.iter().map(Bytes::as_ref)
   }
 
   /// Append an IPv4 address.
@@ -180,7 +182,7 @@ impl ServiceRecords {
 
   /// Append a TXT segment.
   pub fn add_txt_segment(&mut self, segment: Vec<u8>) -> &mut Self {
-    self.txt.push(segment);
+    self.txt.push(segment.into());
     self
   }
 

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -5,6 +5,9 @@ mod respond;
 mod schedule;
 mod state;
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+use bytes::Bytes;
+
 /// Which of OUR owner names a known-answer's record name matched. §7.1
 /// suppression is per RRset, and an RRset is identified by (name, type, class,
 /// rdata). A known-answer with our rtype + rdata but a DIFFERENT owner name is a
@@ -96,7 +99,7 @@ const CONFLICT_REPROBE_MIN_INTERVAL: core::time::Duration = core::time::Duration
 struct PeerRecord {
   rtype: crate::wire::ResourceType,
   /// Canonical byte form of the rdata (same encoding used by KAS hashing).
-  canonical: std::vec::Vec<u8>,
+  canonical: Bytes,
 }
 
 /// A per-source bucket of probe records observed during the current probe round.
@@ -275,7 +278,7 @@ fn compare_rr_sets_we_lose(
       .map(|p| {
         let mut buf = std::vec::Vec::new();
         buf.extend_from_slice(&p.rtype.to_u16().to_be_bytes());
-        buf.extend_from_slice(&p.canonical);
+        buf.extend_from_slice(&p.canonical[..]);
         buf
       })
       .collect();
@@ -1186,7 +1189,7 @@ where
         };
         let mut scratch = std::vec::Vec::new();
         let canonical = match respond::canonical_rdata_for_hash(&view, &mut scratch) {
-          Ok(c) => c.to_vec(),
+          Ok(c) => Bytes::copy_from_slice(c),
           Err(_) => return, // canonicalization error — drop without touching buckets
         };
         let rtype = pc.record().rtype();

--- a/mdns-proto/src/service/respond.rs
+++ b/mdns-proto/src/service/respond.rs
@@ -193,9 +193,11 @@ pub(crate) fn write_probe(records: &ServiceRecords, out: &mut [u8]) -> Result<us
     records.port(),
     records.host(),
   )?;
-  // TXT — collect segments into a Vec to avoid lifetime issues with the closure
-  let txt: std::vec::Vec<std::vec::Vec<u8>> = records.txt_segments().map(|s| s.to_vec()).collect();
-  b.push_txt_authority(records.instance(), records.ttl_secs(), &txt)?;
+  b.push_txt_authority(
+    records.instance(),
+    records.ttl_secs(),
+    records.txt_segments(),
+  )?;
   for a in records.a_addrs_slice() {
     b.push_a_authority(records.host(), records.ttl_secs(), *a)?;
   }
@@ -282,8 +284,12 @@ pub(crate) fn write_announce(
     true,
   )?;
   // TXT — unique record: set cache-flush bit.
-  let txt: std::vec::Vec<std::vec::Vec<u8>> = records.txt_segments().map(|s| s.to_vec()).collect();
-  b.push_txt_answer(records.instance(), records.ttl_secs(), &txt, true)?;
+  b.push_txt_answer(
+    records.instance(),
+    records.ttl_secs(),
+    records.txt_segments(),
+    true,
+  )?;
   // A records (one per address) — unique: set cache-flush bit.
   for a in records.a_addrs_slice() {
     b.push_a_answer(records.host(), records.ttl_secs(), *a, true)?;
@@ -386,8 +392,7 @@ pub(crate) fn write_legacy_response(
     records.host(),
     false,
   )?;
-  let txt: std::vec::Vec<std::vec::Vec<u8>> = records.txt_segments().map(|s| s.to_vec()).collect();
-  b.push_txt_answer(records.instance(), ttl, &txt, false)?;
+  b.push_txt_answer(records.instance(), ttl, records.txt_segments(), false)?;
   for a in records.a_addrs_slice() {
     b.push_a_answer(records.host(), ttl, *a, false)?;
   }
@@ -701,11 +706,14 @@ where
   {
     scratch.clear();
     write_canonical_txt(records.txt_segments(), &mut scratch);
-    let txt: std::vec::Vec<std::vec::Vec<u8>> =
-      records.txt_segments().map(|s| s.to_vec()).collect();
     if !hint_matches(ResourceType::Txt, &scratch) {
       // TXT — unique record: set cache-flush bit.
-      b.push_txt_answer(records.instance(), records.ttl_secs(), &txt, true)?;
+      b.push_txt_answer(
+        records.instance(),
+        records.ttl_secs(),
+        records.txt_segments(),
+        true,
+      )?;
       emitted.txt = true;
     }
   }

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -3320,7 +3320,7 @@ fn tiebreak_always_includes_empty_txt() {
         .to_vec();
       peer_probes_a[0].records.push(PeerRecord {
         rtype: rref.rtype(),
-        canonical,
+        canonical: canonical.into(),
       });
     }
 
@@ -3362,7 +3362,7 @@ fn tiebreak_always_includes_empty_txt() {
       .to_vec();
     peer_probes_b[0].records.push(PeerRecord {
       rtype: srv_ref.rtype(),
-      canonical,
+      canonical: canonical.into(),
     });
 
     // peer set {SRV(631)} starts with 0x0021; our set starts with 0x0010 (TXT)

--- a/mdns-proto/src/wire/record/mod.rs
+++ b/mdns-proto/src/wire/record/mod.rs
@@ -18,6 +18,9 @@ pub use srv::Srv;
 #[allow(unused_imports)]
 pub use txt::{Txt, TxtSegments};
 
+#[cfg(any(feature = "alloc", feature = "std"))]
+use bytes::Bytes;
+
 use super::{NameRef, ResourceClass, ResourceType};
 use crate::error::{BufferTooShortDetail, ParseError, RdlengthOverrunDetail};
 
@@ -210,7 +213,7 @@ impl<'a> Ref<'a> {
   /// additionally case-folds so two encodings differing only in name case (or
   /// compression) compare equal.
   #[cfg(any(feature = "alloc", feature = "std"))]
-  pub(crate) fn canonical_rdata(&self) -> Result<std::vec::Vec<u8>, ParseError> {
+  pub(crate) fn canonical_rdata(&self) -> Result<Bytes, ParseError> {
     self.canonical_rdata_inner(false)
   }
 
@@ -223,22 +226,22 @@ impl<'a> Ref<'a> {
   /// cache). The cache never surfaces rdata for display, so folding is safe
   /// there.
   #[cfg(any(feature = "alloc", feature = "std"))]
-  pub(crate) fn canonical_rdata_folded(&self) -> Result<std::vec::Vec<u8>, ParseError> {
+  pub(crate) fn canonical_rdata_folded(&self) -> Result<Bytes, ParseError> {
     self.canonical_rdata_inner(true)
   }
 
   #[cfg(any(feature = "alloc", feature = "std"))]
-  fn canonical_rdata_inner(&self, fold_case: bool) -> Result<std::vec::Vec<u8>, ParseError> {
+  fn canonical_rdata_inner(&self, fold_case: bool) -> Result<Bytes, ParseError> {
     match self.rdata_view()? {
       Rdata::Ptr(p) => {
         let mut out = std::vec::Vec::new();
         p.target().write_wire(&mut out, fold_case)?;
-        Ok(out)
+        Ok(Bytes::from(out))
       }
       Rdata::Cname(c) => {
         let mut out = std::vec::Vec::new();
         c.target().write_wire(&mut out, fold_case)?;
-        Ok(out)
+        Ok(Bytes::from(out))
       }
       Rdata::Srv(s) => {
         let mut out = std::vec::Vec::new();
@@ -246,13 +249,13 @@ impl<'a> Ref<'a> {
         out.extend_from_slice(&s.weight().to_be_bytes());
         out.extend_from_slice(&s.port().to_be_bytes());
         s.target().write_wire(&mut out, fold_case)?;
-        Ok(out)
+        Ok(Bytes::from(out))
       }
       Rdata::Nsec(n) => {
         let mut out = std::vec::Vec::new();
         n.next_name().write_wire(&mut out, fold_case)?;
         out.extend_from_slice(n.type_bitmap_slice());
-        Ok(out)
+        Ok(Bytes::from(out))
       }
       // Truly-unknown types are opaque (RFC 3597 §4 forbids name compression in
       // them) so raw bytes are a stable identity — EXCEPT a well-known
@@ -263,7 +266,7 @@ impl<'a> Ref<'a> {
         if self.rtype.is_unhandled_compressible_name() {
           return Err(ParseError::UnsupportedNameBearingType(self.rtype.to_u16()));
         }
-        Ok(bytes.to_vec())
+        Ok(Bytes::copy_from_slice(bytes))
       }
       Rdata::Txt(t) => {
         // TXT rdata is a sequence of length-prefixed strings (RFC 6763
@@ -288,11 +291,11 @@ impl<'a> Ref<'a> {
         if !wrote_any {
           out.push(0);
         }
-        Ok(out)
+        Ok(Bytes::from(out))
       }
       // A / AAAA carry no domain name and no internal structure — copy verbatim.
       // (`_` also satisfies the `#[non_exhaustive]` enum.)
-      _ => Ok(self.rdata().to_vec()),
+      _ => Ok(Bytes::copy_from_slice(self.rdata())),
     }
   }
 }


### PR DESCRIPTION
## Summary
Allocation/clone reduction across the mDNS stack, from a clone-hotspot audit. Three independent changes:

1. **`perf(drivers)`: discovery maps keyed by `SmolStr`** — the reactor/compio resolvers fold each discovered name to ASCII-lowercase for HashMap/HashSet keys (builders, host_addrs, hosts_queried). That allocated a `String` per PTR/SRV/A/AAAA answer and cloned it into every map/Step. DNS-SD names fit `SmolStr`'s 23-byte inline buffer, so the fold builds inline and key clones are O(1).

2. **`perf(proto)`: rdata held as `bytes::Bytes`** — `canonical_rdata()`/`_folded()` return `Bytes`; `CacheEntry.rdata` and `CollectedAnswer.rdata`/`rdata_key` hold `Bytes`. rdata is build-once-then-read, so cloning a cache entry (dedup scan, reactive-evict retry) or a collected answer (per-answer pooling under an RRSet flood) is an O(1) refcount bump, not a heap copy. `Cache::try_insert`/`CollectedAnswer::from_parts` take `impl Into<Bytes>`, so `Vec<u8>` call sites are unchanged.

3. **`perf(proto)`: PeerRecord.canonical + ServiceRecords TXT as `Bytes`** — the §8.2 probe-tiebreak record bytes, and TXT segments (`Vec<Vec<u8>>` → `Vec<Bytes>`); `ServiceRecords` clones on withdrawal/rename no longer deep-copy them. Public API unchanged (`add_txt_segment(Vec<u8>)`, `txt_segments() -> &[u8]`).

`bytes` is no_std + alloc, gated to the `any(alloc, std)` cfg (cfg'd out under heapless-only).

## Investigated, not done
**datagram-as-Bytes is a non-win** — the driver recv/send paths are already zero-copy (the datagram is handed to `Endpoint::handle` as a borrowed `&[u8]`; self-send tracking stores an FNV hash, not the bytes).

## Verify
fmt=0 · clippy --workspace --all-features=0 · mdns-proto 341 lib tests · hick-smoltcp/reactor/compio suites · `hack build/test -p mdns-proto --each-feature`=0 (alloc-only + heapless-only legs confirm the `bytes` gating).