### PR TITLE
test: cover oversized-datagram recv survival (issue #2)

### DIFF
--- a/hick-reactor/tests/stats.rs
+++ b/hick-reactor/tests/stats.rs
@@ -101,3 +101,60 @@ async fn stats_packets_tx_after_service_probing() {
     snap.services_registered,
   );
 }
+
+/// Regression for issue #2 ("Weird log on `windows` and `macos`"): an oversized
+/// datagram (larger than the 9000-byte receive buffer) delivered to the *live*
+/// driver must be dropped without killing the receive loop or busy-looping.
+///
+/// Self-validating: it asserts `packets_dropped` actually rose (proving the
+/// oversized datagram reached the receive loop and took the drop-and-continue
+/// path) AND that the endpoint keeps serving afterwards (the loop survived).
+/// Unicast to `127.0.0.1:5353` — loopback's large MTU carries a >9000-byte
+/// datagram in one piece, whereas a multicast send of that size is rejected
+/// with EMSGSIZE; fresh ephemeral source ports spread the blast across the
+/// SO_REUSEPORT sockets bound to 5353.
+#[tokio::test]
+async fn oversized_datagram_dropped_and_loop_survives() {
+  let Some(ep) = loopback_v4_endpoint().await else {
+    return;
+  };
+  tokio::time::sleep(Duration::from_millis(300)).await;
+  let dropped_before = ep.stats().packets_dropped;
+
+  let payload = vec![0xABu8; 10_000];
+  for _ in 0..40 {
+    if let Ok(s) = std::net::UdpSocket::bind("127.0.0.1:0") {
+      let _ = s.send_to(&payload, "127.0.0.1:5353");
+    }
+  }
+  tokio::time::sleep(Duration::from_millis(500)).await;
+
+  let dropped_after = ep.stats().packets_dropped;
+  eprintln!("issue#2 oversized: packets_dropped before={dropped_before} after={dropped_after}");
+  if dropped_after == dropped_before {
+    // No hick socket received the blast: a system mDNS daemon (e.g.
+    // mDNSResponder on macOS) owns :5353 and absorbed the unicast under
+    // SO_REUSEPORT, so there is nothing to assert about our loop here. The
+    // deterministic recv-layer coverage lives in hick_udp
+    // (`recv_with_meta_rejects_oversized_datagram` /
+    // `recv_with_meta_recovers_after_oversized`). Skip rather than false-fail.
+    eprintln!(
+      "oversized blast did not reach a hick socket (system mDNS daemon likely \
+       owns :5353); skipping loop-survival assertion"
+    );
+    return;
+  }
+
+  // The blast reached the loop and was dropped (not parsed, not fatal). Confirm
+  // the receive loop SURVIVED: register a service afterwards and confirm the
+  // driver still processes commands and transmits.
+  let svc = ep
+    .register_service(http_service("post-oversized"))
+    .await
+    .unwrap();
+  let _ = tokio::time::timeout(Duration::from_secs(3), svc.next()).await;
+  assert!(
+    ep.stats().packets_tx > 0,
+    "endpoint must keep sending after the oversized-datagram blast"
+  );
+}

--- a/hick-udp/src/multicast.rs
+++ b/hick-udp/src/multicast.rs
@@ -1175,6 +1175,55 @@ mod tests {
     );
   }
 
+  /// Recovery half of issue #2 ("Weird log on `windows` and `macos`"): after an
+  /// oversized datagram is rejected, the socket must NOT be wedged — the very
+  /// next in-bounds datagram is received intact. The old monolith spun /
+  /// ERROR-spammed on the rejected read; the receive path must instead drop the
+  /// bad datagram and keep serving.
+  #[test]
+  fn recv_with_meta_recovers_after_oversized() {
+    use std::{net::UdpSocket as StdUdp, os::fd::AsRawFd};
+
+    // Retry a non-blocking read past a brief loopback-delivery race.
+    fn recv_settled(fd: std::os::fd::RawFd, buf: &mut [u8]) -> std::io::Result<RecvMeta> {
+      let mut result = recv_with_meta(fd, buf, true);
+      for _ in 0..100 {
+        match &result {
+          Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            result = recv_with_meta(fd, buf, true);
+          }
+          _ => break,
+        }
+      }
+      result
+    }
+
+    let recv = StdUdp::bind("127.0.0.1:0").unwrap();
+    recv.set_nonblocking(true).unwrap();
+    let addr = recv.local_addr().unwrap();
+    let send = StdUdp::bind("127.0.0.1:0").unwrap();
+    let mut buf = [0u8; 64];
+
+    // 1) Oversized datagram (2048 > 64-byte buffer) → rejected as InvalidData.
+    send.send_to(&vec![0xABu8; 2048], addr).unwrap();
+    assert_eq!(
+      recv_settled(recv.as_raw_fd(), &mut buf)
+        .expect_err("oversized must be rejected")
+        .kind(),
+      std::io::ErrorKind::InvalidData,
+    );
+
+    // 2) The socket is NOT wedged: a subsequent in-bounds datagram is received
+    //    intact, proving the receive path keeps serving after the drop.
+    let normal = [0x42u8; 32];
+    send.send_to(&normal, addr).unwrap();
+    let meta = recv_settled(recv.as_raw_fd(), &mut buf)
+      .expect("normal datagram must be received after an oversized drop");
+    assert_eq!(meta.len(), normal.len(), "received length must match");
+    assert_eq!(&buf[..meta.len()], &normal, "received bytes must match");
+  }
+
   #[cfg(unix)]
   #[test]
   #[allow(unsafe_code)]


### PR DESCRIPTION
Closes #2.

## Context

Issue #2 ("Weird log on `windows` and `macos`") reported the old monolithic `agnostic_mdns::server` busy-looping + ERROR-spamming when `recv_from` returned `EINVAL` (macOS) / `WSAEMSGSIZE` (windows) on a datagram larger than the receive buffer — blinding the service until restart.

That code was replaced by the sans-io `mdns-proto` + `hick-udp` driver architecture, which already resolves all three symptoms:

- **Busy-loop** — the receive loop gates on an async `peek_from` readiness await (`hick-reactor/src/driver.rs`), so it parks instead of spinning.
- **Windows `WSAEMSGSIZE`** — the recv buffer defaults to 9000 bytes (RFC 6762 §17); an oversized datagram is consumed + truncated and drop-and-continued (`driver.rs:2018-2087`), never fatal.
- **macOS `EINVAL`** — the path uses `recvmsg`/`WSARecvMsg` into a fixed buffer instead of `MSG_TRUNC`-on-`recv` (the Linux-only flag that `EINVAL`s on macOS).
- The error log moved from `ERROR` to `debug!`.

## What this PR adds

Regression coverage so the fix can't silently regress:

- **`hick-udp::recv_with_meta_recovers_after_oversized`** — deterministic on unix (incl. macOS): an oversized datagram is rejected as `InvalidData` and the socket keeps serving (the next in-bounds datagram arrives intact).
- **`hick-reactor::oversized_datagram_dropped_and_loop_survives`** — self-validating driver-loop survival via `stats.packets_dropped`; it skips gracefully when a system mDNS daemon owns `:5353` (macOS, where mDNSResponder absorbs the unicast under `SO_REUSEPORT`) and runs fully on Linux/Windows CI.

The recv-layer classification (`recv_with_meta_rejects_oversized_datagram`) and stats accounting (`count_consumed_oversized`) were already covered.