### PR TITLE
perf: reduce allocations & deep clones; fix + harden inbound name decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["hick", "hick-trace", "mdns-proto", "hick-udp", "hick-reactor", "hick
 resolver = "3"
 
 [workspace.dependencies]
+bytes = { version = "1", default-features = false }
 hick = { version = "0.1", path = "hick", default-features = false }
 hick-trace = { version = "0.1", path = "hick-trace", default-features = false }
 mdns-proto = { version = "0.5", path = "mdns-proto", default-features = false }

--- a/hick-compio/Cargo.toml
+++ b/hick-compio/Cargo.toml
@@ -20,9 +20,10 @@ metrics = ["stats", "mdns-proto/metrics", "hick-trace/metrics"]
 stats = ["mdns-proto/stats", "hick-trace/stats"]
 
 [dependencies]
+bytes = { workspace = true, features = ["default"] }
 mdns-proto = { workspace = true, features = ["std", "slab"] }
 hick-udp.workspace = true
-hick-trace = { workspace = true }
+hick-trace.workspace = true
 tracing = { workspace = true, optional = true, features = ["attributes", "std"] }
 compio = { version = "0.19", features = ["time"] }
 compio-net = "0.12"
@@ -31,23 +32,23 @@ compio-runtime = "0.12"
 compio-buf = "0.8.2"
 futures = { workspace = true, features = ["std", "async-await"] }
 event-listener = "5"
-getifs = { workspace = true }
+getifs.workspace = true
 slab = { workspace = true, features = ["std"] }
 smol_str = { workspace = true, features = ["std"] }
 rand = { workspace = true, features = ["std", "std_rng", "sys_rng", "thread_rng"] }
 thiserror = { workspace = true, features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
+libc.workspace = true
 
 [dev-dependencies]
 compio = { version = "0.19", features = ["macros", "time"] }
 # Pin the loopback interface in the end-to-end driver integration tests.
-getifs = { workspace = true }
+getifs.workspace = true
 # Always-enabled subscriber installed before the unit-test run (see trace_cov)
 # so the instrumentation call sites evaluate their fields and earn coverage.
-tracing-core = { workspace = true }
-ctor = { workspace = true }
+tracing-core.workspace = true
+ctor.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hick-compio/src/discovery.rs
+++ b/hick-compio/src/discovery.rs
@@ -10,13 +10,17 @@
 //! [`resolve_instance`](crate::Endpoint::resolve_instance) APIs wire these
 //! together to drive the RFC 6763 browse → resolve chain.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+  collections::{HashMap, HashSet, VecDeque},
+  sync::Arc,
+};
 
 use core::{
   net::{IpAddr, Ipv4Addr, Ipv6Addr},
   time::Duration,
 };
 
+use bytes::Bytes;
 use futures::future::select_all;
 use mdns_proto::{
   Name, QuerySpec,
@@ -48,9 +52,9 @@ pub struct ServiceEntry {
   pub(crate) instance: Name,
   pub(crate) host: Name,
   pub(crate) port: u16,
-  pub(crate) ipv4: Vec<Ipv4Addr>,
-  pub(crate) ipv6: Vec<Ipv6Addr>,
-  pub(crate) txt: Vec<Vec<u8>>,
+  pub(crate) ipv4: Arc<[Ipv4Addr]>,
+  pub(crate) ipv6: Arc<[Ipv6Addr]>,
+  pub(crate) txt: Arc<[Bytes]>,
 }
 
 impl ServiceEntry {
@@ -99,7 +103,7 @@ impl ServiceEntry {
   /// DNS-SD usage, but treated as opaque bytes since TXT data may be binary). A
   /// service with no metadata has a single empty segment (RFC 6763 §6.1).
   #[inline]
-  pub fn txt(&self) -> &[Vec<u8>] {
+  pub fn txt(&self) -> &[Bytes] {
     &self.txt
   }
 }
@@ -175,11 +179,10 @@ pub(crate) fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
 /// (RFC 6762 §16), so the lower-cased string form is the canonical key for
 /// the resolver's per-instance / per-host maps.
 pub(crate) fn fold(name: &Name) -> SmolStr {
-  name
-    .as_str()
-    .chars()
-    .map(|c| c.to_ascii_lowercase())
-    .collect()
+  // `Name` is already stored canonical-lowercase (RFC 6762 §16), so a plain
+  // `SmolStr::new` suffices — and inlines names ≤23 bytes, whereas collecting
+  // from a `char` iterator always takes SmolStr's heap path.
+  SmolStr::new(name.as_str())
 }
 
 /// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
@@ -227,11 +230,11 @@ pub(crate) fn parse_srv(rdata: &[u8]) -> Option<(Name, u16)> {
 /// Parse a TXT rdata slice into its length-prefixed segments
 /// (RFC 1035 §3.3.14 + RFC 6763 §6). Drops a malformed tail rather than
 /// failing the whole record.
-pub(crate) fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
+pub(crate) fn parse_txt(rdata: &[u8]) -> Vec<Bytes> {
   Txt::from_rdata(rdata)
     .segments()
     .map_while(Result::ok)
-    .map(<[u8]>::to_vec)
+    .map(Bytes::copy_from_slice)
     .collect()
 }
 
@@ -288,7 +291,7 @@ pub(crate) struct Builder {
   pub(crate) port: u16,
   pub(crate) ipv4: Vec<Ipv4Addr>,
   pub(crate) ipv6: Vec<Ipv6Addr>,
-  pub(crate) txt: Option<Vec<Vec<u8>>>,
+  pub(crate) txt: Option<Vec<Bytes>>,
   pub(crate) emitted: bool,
 }
 
@@ -317,9 +320,9 @@ impl Builder {
       instance: self.instance.clone(),
       host: self.host.clone()?,
       port: self.port,
-      ipv4: self.ipv4.clone(),
-      ipv6: self.ipv6.clone(),
-      txt: self.txt.clone()?,
+      ipv4: self.ipv4.as_slice().into(),
+      ipv6: self.ipv6.as_slice().into(),
+      txt: self.txt.as_deref()?.into(),
     })
   }
 }
@@ -442,7 +445,7 @@ impl Resolver {
     ]
   }
 
-  pub(crate) fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
+  pub(crate) fn on_txt(&mut self, inst_key: &str, segs: Vec<Bytes>) {
     let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
       // A TXT change to an already-surfaced instance must re-emit so the
@@ -738,7 +741,7 @@ mod tests {
     r.on_ptr(i2);
     // i1 resolves: host + port, then its host gets an address.
     r.on_srv(&k1, host.clone(), 8080);
-    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_txt(&k1, vec![b"a=1".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     // i1 is now complete.
     let first = r.take_ready().expect("i1 should complete");
@@ -747,7 +750,7 @@ mod tests {
 
     // i2's SRV arrives AFTER the A answer. It must adopt the cached address.
     r.on_srv(&k2, host, 8081);
-    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    r.on_txt(&k2, vec![b"b=2".to_vec().into()]);
     let second = r
       .take_ready()
       .expect("i2 should complete from the host cache");
@@ -776,7 +779,7 @@ mod tests {
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
     assert!(r.take_ready().is_none(), "must not emit without TXT");
     // TXT arrives → now complete.
-    r.on_txt(&k, vec![Vec::new()]); // empty TXT (single empty segment) counts
+    r.on_txt(&k, vec![Bytes::new()]); // empty TXT (single empty segment) counts
     assert!(r.take_ready().is_some(), "complete once TXT present");
   }
 
@@ -792,7 +795,7 @@ mod tests {
       let k = fold(&inst);
       r.on_ptr(inst);
       r.on_srv(&k, host.clone(), 7000);
-      r.on_txt(&k, vec![b"k=v".to_vec()]);
+      r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     }
     assert!(
       r.take_ready().is_none(),
@@ -818,7 +821,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
     let first = r.take_ready().expect("first emit on A");
     assert_eq!(first.ipv4_addresses().len(), 1);
@@ -847,7 +850,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     for i in 0..(MAX_ADDRS_PER_HOST as u32 + 8) {
       let o = i.to_be_bytes();
       r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, o[1], o[2], o[3])));
@@ -897,7 +900,7 @@ mod tests {
     let hk2 = fold(&h2);
     r.on_ptr(inst);
     r.on_srv(&k, h1, 8000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let first = r.take_ready().expect("resolves on h1");
     assert_eq!(first.host().as_str(), "h1.local.");
@@ -928,7 +931,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 0);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let e = r
       .take_ready()
@@ -949,16 +952,16 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"v=1".to_vec()]);
+    r.on_txt(&k, vec![b"v=1".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let first = r.take_ready().expect("first emit");
-    assert_eq!(first.txt(), [b"v=1".to_vec()]);
+    assert_eq!(first.txt(), [Bytes::from_static(b"v=1")]);
     // Changed TXT → re-emit with the new metadata.
-    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    r.on_txt(&k, vec![b"v=2".to_vec().into()]);
     let second = r.take_ready().expect("re-emit on TXT change");
-    assert_eq!(second.txt(), [b"v=2".to_vec()]);
+    assert_eq!(second.txt(), [Bytes::from_static(b"v=2")]);
     // Duplicate TXT → no re-emit.
-    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    r.on_txt(&k, vec![b"v=2".to_vec().into()]);
     assert!(r.take_ready().is_none(), "duplicate TXT must not re-emit");
   }
 
@@ -981,14 +984,14 @@ mod tests {
     // i1 resolves on `shared`, populating the host-address cache.
     r.on_ptr(i1);
     r.on_srv(&k1, shared.clone(), 8000);
-    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_txt(&k1, vec![b"a=1".to_vec().into()]);
     r.on_addr(&shk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)));
     r.take_ready().expect("i1 resolves on shared");
 
     // i2 first resolves on a DIFFERENT host.
     r.on_ptr(i2);
     r.on_srv(&k2, other, 9000);
-    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    r.on_txt(&k2, vec![b"b=2".to_vec().into()]);
     r.on_addr(&ohk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)));
     let i2_first = r.take_ready().expect("i2 resolves on other");
     assert_eq!(i2_first.host().as_str(), "other.local.");
@@ -1022,7 +1025,7 @@ mod tests {
     let hk1 = fold(&h1);
     r.on_ptr(inst);
     r.on_srv(&k, h1, 8000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     assert!(r.take_ready().is_some(), "instance completes on h1");
 
@@ -1030,7 +1033,7 @@ mod tests {
     for i in 0..10u16 {
       let h = Name::try_from_str(&format!("m{i}.local.")).unwrap();
       r.on_srv(&k, h, 9000 + i);
-      r.on_txt(&k, vec![format!("v={i}").into_bytes()]);
+      r.on_txt(&k, vec![format!("v={i}").into_bytes().into()]);
     }
     // h1 took one host slot; at most one more (cap 2) is ever queried.
     assert!(r.hosts_queried.len() <= 2, "host set stays bounded");

--- a/hick-compio/src/driver.rs
+++ b/hick-compio/src/driver.rs
@@ -201,6 +201,13 @@ pub(crate) struct State {
   /// state and `clear()`ed each iteration so the per-iteration GC allocates
   /// nothing in steady state.
   pub(crate) completed_withdrawals: Vec<ServiceHandle>,
+  /// Reusable scratch for the service/query handle snapshots taken by the
+  /// transmit pump (`poll_one_transmit`) and `push_service_updates`: those loops
+  /// early-`return` and call `&mut self` withdrawal methods mid-iteration, so they
+  /// can't hold a map borrow across the body — they reuse these buffers instead of
+  /// allocating a fresh `Vec` per pump call. `clear()`ed at the start of each use.
+  pub(crate) svc_handle_scratch: Vec<ServiceHandle>,
+  pub(crate) query_handle_scratch: Vec<QueryHandle>,
   /// Bound interface index (1-based) used for §11 link-local scoping.
   pub(crate) bound_interface: u32,
   /// Cached local subnets used for the §11 source-address fallback when the
@@ -240,6 +247,8 @@ impl State {
       queries: HashMap::new(),
       recent_sends: Vec::new(),
       completed_withdrawals: Vec::new(),
+      svc_handle_scratch: Vec::new(),
+      query_handle_scratch: Vec::new(),
       bound_interface: 0,
       local_subnets: Vec::new(),
       max_payload,
@@ -456,23 +465,27 @@ impl State {
   /// at T8 only the endpoint cache sweep and query timeouts are exposed.
   pub(crate) fn fire_timeouts(&mut self, now: StdInstant) {
     let _ = self.endpoint.handle_timeout(now);
-    let handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
-    for h in handles {
+    // Split-borrow so the query sweep reads `queries` in place and ticks via the
+    // disjoint `endpoint` field — no per-tick Vec snapshot, and the `errored`
+    // guard reuses the iterator's `ctx` instead of a second map lookup.
+    let Self {
+      endpoint, queries, ..
+    } = &mut *self;
+    for (&h, ctx) in queries.iter() {
       // Don't tick a structurally-dead query's proto (see `QueryCtx::errored`).
-      if self.queries.get(&h).is_some_and(|c| c.errored) {
+      if ctx.errored {
         continue;
       }
-      let _ = self.endpoint.handle_query_timeout(h, now);
+      let _ = endpoint.handle_query_timeout(h, now);
     }
-    let svc_handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
-    for h in svc_handles {
-      if let Some(ctx) = self.services.get_mut(&h) {
-        // Don't tick a withdrawn (cancelled) or structurally-dead (errored)
-        // service's proto — a dead proto must not be driven (see
-        // `ServiceCtx::errored`).
-        if !ctx.cancelled && !ctx.errored {
-          let _ = ctx.proto.handle_timeout(now);
-        }
+    // The proto tick touches only the service's own ctx, so iterate
+    // `values_mut()` in place rather than snapshotting handles into a Vec.
+    for ctx in self.services.values_mut() {
+      // Don't tick a withdrawn (cancelled) or structurally-dead (errored)
+      // service's proto — a dead proto must not be driven (see
+      // `ServiceCtx::errored`).
+      if !ctx.cancelled && !ctx.errored {
+        let _ = ctx.proto.handle_timeout(now);
       }
     }
   }
@@ -519,8 +532,14 @@ impl State {
     // `&mut` access to `self.endpoint` (for `handle_service_renamed`) and
     // `self.services.get_mut(&h)` — a single `values_mut()` borrow would lock
     // `self.endpoint` out.
-    let handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
-    for h in handles {
+    self.svc_handle_scratch.clear();
+    self
+      .svc_handle_scratch
+      .extend(self.services.keys().copied());
+    let mut i = 0;
+    while i < self.svc_handle_scratch.len() {
+      let h = self.svc_handle_scratch[i];
+      i += 1;
       // A structurally-dead proto (see `ServiceCtx::errored`) is never polled — it
       // can't produce more updates. Its escalation `Conflict` already sits in the
       // handle-owned mailbox's reserved terminal slot and is drained directly by
@@ -640,8 +659,14 @@ impl State {
     now: StdInstant,
     scratch: &mut [u8],
   ) -> Option<(core::net::SocketAddr, usize, TransmitOrigin)> {
-    let svc_handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
-    for h in svc_handles {
+    self.svc_handle_scratch.clear();
+    self
+      .svc_handle_scratch
+      .extend(self.services.keys().copied());
+    let mut i = 0;
+    while i < self.svc_handle_scratch.len() {
+      let h = self.svc_handle_scratch[i];
+      i += 1;
       // Skip a cancelled (withdrawn, awaiting sweep) or errored (structurally
       // dead, see `ServiceCtx::errored`) service so neither is re-polled into a
       // busy-spin.
@@ -730,8 +755,14 @@ impl State {
       }
     }
 
-    let q_handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
-    for h in q_handles {
+    self.query_handle_scratch.clear();
+    self
+      .query_handle_scratch
+      .extend(self.queries.keys().copied());
+    let mut i = 0;
+    while i < self.query_handle_scratch.len() {
+      let h = self.query_handle_scratch[i];
+      i += 1;
       let Some(ctx) = self.queries.get_mut(&h) else {
         continue;
       };

--- a/hick-reactor/Cargo.toml
+++ b/hick-reactor/Cargo.toml
@@ -25,6 +25,7 @@ metrics = ["stats", "mdns-proto/metrics", "hick-trace/metrics"]
 stats = ["mdns-proto/stats", "hick-trace/stats"]
 
 [dependencies]
+bytes = { workspace = true, features = ["default"] }
 mdns-proto = { workspace = true, features = ["std", "slab"] }
 hick-udp.workspace = true
 hick-trace = { workspace = true }

--- a/hick-reactor/src/discovery.rs
+++ b/hick-reactor/src/discovery.rs
@@ -40,6 +40,7 @@ use std::{
   time::{Duration, Instant},
 };
 
+use bytes::Bytes;
 use futures::{FutureExt, StreamExt, pin_mut, select_biased, stream::SelectAll};
 use mdns_proto::{
   Name, QuerySpec,
@@ -72,9 +73,9 @@ pub struct ServiceEntry {
   instance: Name,
   host: Name,
   port: u16,
-  ipv4: Vec<Ipv4Addr>,
-  ipv6: Vec<Ipv6Addr>,
-  txt: Vec<Vec<u8>>,
+  ipv4: Arc<[Ipv4Addr]>,
+  ipv6: Arc<[Ipv6Addr]>,
+  txt: Arc<[Bytes]>,
 }
 
 impl ServiceEntry {
@@ -123,7 +124,7 @@ impl ServiceEntry {
   /// DNS-SD usage, but treated as opaque bytes since TXT data may be binary). A
   /// service with no metadata has a single empty segment (RFC 6763 §6.1).
   #[inline]
-  pub fn txt(&self) -> &[Vec<u8>] {
+  pub fn txt(&self) -> &[Bytes] {
     &self.txt
   }
 }
@@ -234,7 +235,7 @@ struct Builder {
   port: u16,
   ipv4: Vec<Ipv4Addr>,
   ipv6: Vec<Ipv6Addr>,
-  txt: Option<Vec<Vec<u8>>>,
+  txt: Option<Vec<Bytes>>,
   emitted: bool,
 }
 
@@ -263,9 +264,9 @@ impl Builder {
       instance: self.instance.clone(),
       host: self.host.clone()?,
       port: self.port,
-      ipv4: self.ipv4.clone(),
-      ipv6: self.ipv6.clone(),
-      txt: self.txt.clone()?,
+      ipv4: self.ipv4.as_slice().into(),
+      ipv6: self.ipv6.as_slice().into(),
+      txt: self.txt.as_deref()?.into(),
     })
   }
 }
@@ -394,7 +395,7 @@ impl Resolver {
     ]
   }
 
-  fn on_txt(&mut self, inst_key: &str, segs: Vec<Vec<u8>>) {
+  fn on_txt(&mut self, inst_key: &str, segs: Vec<Bytes>) {
     let mut changed = false;
     if let Some(b) = self.builders.get_mut(inst_key) {
       // A TXT change to an already-surfaced instance must re-emit so the
@@ -908,11 +909,10 @@ fn push_capped<T: PartialEq>(v: &mut Vec<T>, item: T) -> bool {
 /// Case-fold a name to its lookup key (DNS names are case-insensitive,
 /// RFC 6762 §16).
 fn fold(name: &Name) -> SmolStr {
-  name
-    .as_str()
-    .chars()
-    .map(|c| c.to_ascii_lowercase())
-    .collect()
+  // `Name` is already stored canonical-lowercase (RFC 6762 §16), so a plain
+  // `SmolStr::new` suffices — and inlines names ≤23 bytes, whereas collecting
+  // from a `char` iterator always takes SmolStr's heap path.
+  SmolStr::new(name.as_str())
 }
 
 /// Decode an owner-less wire-form domain name (a decompressed PTR/SRV target as
@@ -955,11 +955,11 @@ fn parse_srv(rdata: &[u8]) -> Option<(Name, u16)> {
 }
 
 /// Parse a TXT rdata slice into its segments (dropping a malformed tail).
-fn parse_txt(rdata: &[u8]) -> Vec<Vec<u8>> {
+fn parse_txt(rdata: &[u8]) -> Vec<Bytes> {
   Txt::from_rdata(rdata)
     .segments()
     .map_while(Result::ok)
-    .map(<[u8]>::to_vec)
+    .map(Bytes::copy_from_slice)
     .collect()
 }
 
@@ -1039,7 +1039,7 @@ mod tests {
     r.on_ptr(i2);
     // i1 resolves: host + port, then its host gets an address.
     r.on_srv(&k1, host.clone(), 8080);
-    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_txt(&k1, vec![b"a=1".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     // i1 is now complete.
     let first = r.take_ready().expect("i1 should complete");
@@ -1048,7 +1048,7 @@ mod tests {
 
     // i2's SRV arrives AFTER the A answer. It must adopt the cached address.
     r.on_srv(&k2, host, 8081);
-    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    r.on_txt(&k2, vec![b"b=2".to_vec().into()]);
     let second = r
       .take_ready()
       .expect("i2 should complete from the host cache");
@@ -1077,7 +1077,7 @@ mod tests {
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
     assert!(r.take_ready().is_none(), "must not emit without TXT");
     // TXT arrives → now complete.
-    r.on_txt(&k, vec![Vec::new()]); // empty TXT (single empty segment) counts
+    r.on_txt(&k, vec![Bytes::new()]); // empty TXT (single empty segment) counts
     assert!(r.take_ready().is_some(), "complete once TXT present");
   }
 
@@ -1093,7 +1093,7 @@ mod tests {
       let k = fold(&inst);
       r.on_ptr(inst);
       r.on_srv(&k, host.clone(), 7000);
-      r.on_txt(&k, vec![b"k=v".to_vec()]);
+      r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     }
     assert!(
       r.take_ready().is_none(),
@@ -1119,7 +1119,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
     let first = r.take_ready().expect("first emit on A");
     assert_eq!(first.ipv4_addresses().len(), 1);
@@ -1148,7 +1148,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     for i in 0..(MAX_ADDRS_PER_HOST as u32 + 8) {
       let o = i.to_be_bytes();
       r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, o[1], o[2], o[3])));
@@ -1198,7 +1198,7 @@ mod tests {
     let hk2 = fold(&h2);
     r.on_ptr(inst);
     r.on_srv(&k, h1, 8000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let first = r.take_ready().expect("resolves on h1");
     assert_eq!(first.host().as_str(), "h1.local.");
@@ -1229,7 +1229,7 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 0);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let e = r
       .take_ready()
@@ -1250,16 +1250,16 @@ mod tests {
     let hk = fold(&host);
     r.on_ptr(inst);
     r.on_srv(&k, host, 7000);
-    r.on_txt(&k, vec![b"v=1".to_vec()]);
+    r.on_txt(&k, vec![b"v=1".to_vec().into()]);
     r.on_addr(&hk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     let first = r.take_ready().expect("first emit");
-    assert_eq!(first.txt(), [b"v=1".to_vec()]);
+    assert_eq!(first.txt(), [Bytes::from_static(b"v=1")]);
     // Changed TXT → re-emit with the new metadata.
-    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    r.on_txt(&k, vec![b"v=2".to_vec().into()]);
     let second = r.take_ready().expect("re-emit on TXT change");
-    assert_eq!(second.txt(), [b"v=2".to_vec()]);
+    assert_eq!(second.txt(), [Bytes::from_static(b"v=2")]);
     // Duplicate TXT → no re-emit.
-    r.on_txt(&k, vec![b"v=2".to_vec()]);
+    r.on_txt(&k, vec![b"v=2".to_vec().into()]);
     assert!(r.take_ready().is_none(), "duplicate TXT must not re-emit");
   }
 
@@ -1282,14 +1282,14 @@ mod tests {
     // i1 resolves on `shared`, populating the host-address cache.
     r.on_ptr(i1);
     r.on_srv(&k1, shared.clone(), 8000);
-    r.on_txt(&k1, vec![b"a=1".to_vec()]);
+    r.on_txt(&k1, vec![b"a=1".to_vec().into()]);
     r.on_addr(&shk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9)));
     r.take_ready().expect("i1 resolves on shared");
 
     // i2 first resolves on a DIFFERENT host.
     r.on_ptr(i2);
     r.on_srv(&k2, other, 9000);
-    r.on_txt(&k2, vec![b"b=2".to_vec()]);
+    r.on_txt(&k2, vec![b"b=2".to_vec().into()]);
     r.on_addr(&ohk, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8)));
     let i2_first = r.take_ready().expect("i2 resolves on other");
     assert_eq!(i2_first.host().as_str(), "other.local.");
@@ -1323,7 +1323,7 @@ mod tests {
     let hk1 = fold(&h1);
     r.on_ptr(inst);
     r.on_srv(&k, h1, 8000);
-    r.on_txt(&k, vec![b"k=v".to_vec()]);
+    r.on_txt(&k, vec![b"k=v".to_vec().into()]);
     r.on_addr(&hk1, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
     assert!(r.take_ready().is_some(), "instance completes on h1");
 
@@ -1331,7 +1331,7 @@ mod tests {
     for i in 0..10u16 {
       let h = Name::try_from_str(&format!("m{i}.local.")).unwrap();
       r.on_srv(&k, h, 9000 + i);
-      r.on_txt(&k, vec![format!("v={i}").into_bytes()]);
+      r.on_txt(&k, vec![format!("v={i}").into_bytes().into()]);
     }
     // h1 took one host slot; at most one more (cap 2) is ever queried.
     assert!(r.hosts_queried.len() <= 2, "host set stays bounded");

--- a/hick-reactor/src/driver.rs
+++ b/hick-reactor/src/driver.rs
@@ -504,9 +504,14 @@ impl<N: Net> DriverState<N> {
       }
       let _ = ctx.proto.handle_timeout(now);
     }
-    let query_handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
-    for h in query_handles {
-      let _ = self.endpoint.handle_query_timeout(h, now);
+    // Split-borrow `endpoint` from `queries` so the sweep iterates the query map
+    // in place — `handle_query_timeout` touches only the disjoint `endpoint`
+    // field — instead of snapshotting every handle into a fresh per-tick Vec.
+    let Self {
+      endpoint, queries, ..
+    } = &mut *self;
+    for &h in queries.keys() {
+      let _ = endpoint.handle_query_timeout(h, now);
     }
   }
 

--- a/hick-reactor/tests/loopback_lookup.rs
+++ b/hick-reactor/tests/loopback_lookup.rs
@@ -359,10 +359,7 @@ async fn loopback_browse_resolves_service_entry() {
     entry.ipv4_addresses()
   );
   assert!(
-    entry
-      .txt()
-      .iter()
-      .any(|t| t.as_slice() == b"Local web server"),
+    entry.txt().iter().any(|t| &t[..] == b"Local web server"),
     "expected TXT 'Local web server' in {:?}",
     entry.txt()
   );
@@ -450,10 +447,7 @@ async fn loopback_resolve_instance_returns_entry() {
     );
   }
   assert!(
-    entry
-      .txt()
-      .iter()
-      .any(|t| t.as_slice() == b"Local web server"),
+    entry.txt().iter().any(|t| &t[..] == b"Local web server"),
     "expected TXT 'Local web server' in {:?}",
     entry.txt()
   );

--- a/hick-smoltcp/src/engine.rs
+++ b/hick-smoltcp/src/engine.rs
@@ -540,6 +540,13 @@ pub struct Engine<I: Instant, R> {
   /// into it and the pump can GC each one's driver slot). Kept on the engine and
   /// `clear()`ed each pump so the per-pump GC allocates nothing in steady state.
   completed_withdrawals: Vec<ServiceHandle>,
+  /// Reusable scratch for the service/query handle snapshots taken by the
+  /// transmit pump (`poll_one_transmit`) and `drain_service_updates`: those loops
+  /// early-`return` and call `&mut self` withdrawal methods mid-iteration, so they
+  /// can't hold a map borrow across the body — they reuse these buffers instead of
+  /// allocating a fresh `Vec` per pump call. `clear()`ed at the start of each use.
+  svc_handle_scratch: Vec<ServiceHandle>,
+  query_handle_scratch: Vec<QueryHandle>,
   /// The multicast transmit path: per-family fan-out, fan-out ordering, and
   /// self-loopback detection.
   tx: Multicaster<I>,
@@ -571,6 +578,8 @@ where
       queries: BTreeMap::new(),
       subnets: Vec::new(),
       completed_withdrawals: Vec::new(),
+      svc_handle_scratch: Vec::new(),
+      query_handle_scratch: Vec::new(),
       tx: Multicaster::new(),
       #[cfg(feature = "stats")]
       stats,
@@ -1019,14 +1028,16 @@ where
   fn fire_timeouts(&mut self, now: I) {
     let _ = self.endpoint.handle_timeout(now);
 
-    let query_handles: Vec<QueryHandle> = self
-      .queries
-      .iter()
-      .filter(|(_, slot)| !slot.errored)
-      .map(|(handle, _)| *handle)
-      .collect();
-    for handle in query_handles {
-      let _ = self.endpoint.handle_query_timeout(handle, now);
+    // Split-borrow so the query sweep reads `queries` in place and ticks via the
+    // disjoint `endpoint` field — no per-tick Vec snapshot.
+    let Self {
+      endpoint, queries, ..
+    } = &mut *self;
+    for (&handle, slot) in queries.iter() {
+      if slot.errored {
+        continue;
+      }
+      let _ = endpoint.handle_query_timeout(handle, now);
     }
 
     for slot in self.services.values_mut() {
@@ -1055,8 +1066,14 @@ where
   /// ([`Self::begin_service_withdrawal`]), which holds the route and resends
   /// before freeing the name. (The old-name detached item was already enqueued.)
   fn drain_service_updates(&mut self, now: I) {
-    let handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
-    for handle in handles {
+    self.svc_handle_scratch.clear();
+    self
+      .svc_handle_scratch
+      .extend(self.services.keys().copied());
+    let mut i = 0;
+    while i < self.svc_handle_scratch.len() {
+      let handle = self.svc_handle_scratch[i];
+      i += 1;
       while let Some(update) = self
         .services
         .get_mut(&handle)
@@ -1176,8 +1193,14 @@ where
     // rather than being advertised with records no §10.1 goodbye could retract.
     let cap = scratch.len().min(MAX_MDNS_MESSAGE);
     let scratch = &mut scratch[..cap];
-    let service_handles: Vec<ServiceHandle> = self.services.keys().copied().collect();
-    for handle in service_handles {
+    self.svc_handle_scratch.clear();
+    self
+      .svc_handle_scratch
+      .extend(self.services.keys().copied());
+    let mut i = 0;
+    while i < self.svc_handle_scratch.len() {
+      let handle = self.svc_handle_scratch[i];
+      i += 1;
       // NLL note: the `slot` borrow is scoped to the `match` block so it ends
       // before the post-match in-iteration `begin_withdrawal` call below.
       let escalated = {
@@ -1217,8 +1240,14 @@ where
       }
     }
 
-    let query_handles: Vec<QueryHandle> = self.queries.keys().copied().collect();
-    for handle in query_handles {
+    self.query_handle_scratch.clear();
+    self
+      .query_handle_scratch
+      .extend(self.queries.keys().copied());
+    let mut i = 0;
+    while i < self.query_handle_scratch.len() {
+      let handle = self.query_handle_scratch[i];
+      i += 1;
       if self.queries.get(&handle).is_some_and(|slot| slot.errored) {
         continue;
       }

--- a/hick/src/lib.rs
+++ b/hick/src/lib.rs
@@ -5,15 +5,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
 
-// `hick` is a thin, batteries-included facade over the family: it wires the
-// Sans-I/O protocol core (`mdns-proto`) to the default async driver
-// (`hick-reactor`). The driver's public surface is flattened to the crate root
-// so the common path is `hick::Endpoint` / `hick::tokio::server(..)`, while the
-// `proto` and `reactor` modules expose the underlying crates in full for power
-// users. Pick the `compio` runtime by depending on `hick-compio` directly, or
-// enable the `smoltcp` / `embassy` features for the bare-metal (`no_std`) engine
-// and its embassy driver.
-
 /// The Sans-I/O mDNS protocol core ([`mdns_proto`]).
 ///
 /// Re-exported in full for direct access to the wire codec, the record cache,

--- a/mdns-proto/src/endpoint.rs
+++ b/mdns-proto/src/endpoint.rs
@@ -1773,31 +1773,12 @@ where
         if !populate_cache || !is_response {
           continue;
         }
-        // Build an owned Name from the wire label sequence.
-        let name_opt: Option<Name> = {
-          let mut s = std::string::String::new();
-          let mut ok = true;
-          for label in r.name().labels() {
-            match label {
-              Ok(bytes) => {
-                for &b in bytes {
-                  s.push(b.to_ascii_lowercase() as char);
-                }
-                s.push('.');
-              }
-              Err(_) => {
-                ok = false;
-                break;
-              }
-            }
-          }
-          if ok {
-            Name::try_from_str(&s).ok()
-          } else {
-            None
-          }
-        };
-        let name = match name_opt {
+        // Build an owned Name directly from the wire label sequence. Bails
+        // (drops the record) on a malformed label, non-UTF-8 bytes — DNS-SD
+        // names are UTF-8 (RFC 6763 §4.1) — or a length violation. Avoids the
+        // throwaway presentation `String` the old loop assembled, and unlike a
+        // `byte as char` join never Latin-1-mangles a multi-byte UTF-8 label.
+        let name = match Name::from_wire_labels(r.name().labels()) {
           Some(n) => n,
           None => continue,
         };
@@ -9809,14 +9790,16 @@ pub(crate) const DNS_SD_META_QUERY_NAME: &str = "_services._dns-sd._udp.local.";
 /// matching question is routed to every registered service so each can answer
 /// with a shared PTR `_services._dns-sd._udp.local. -> <its service type>`.
 pub(crate) fn is_meta_query_name(qname: &NameRef<'_>) -> bool {
-  match Name::try_from_str(DNS_SD_META_QUERY_NAME) {
-    Ok(meta) => names_match(&meta, qname),
-    Err(_) => false,
-  }
+  // Compare against the &'static meta-query name directly — no need to
+  // allocate a `Name` (29 bytes, heap-backed) on every routed question.
+  names_match_str(DNS_SD_META_QUERY_NAME, qname)
 }
 
 pub(crate) fn names_match(stored: &Name, incoming: &NameRef<'_>) -> bool {
-  let stored_str = stored.as_str();
+  names_match_str(stored.as_str(), incoming)
+}
+
+pub(crate) fn names_match_str(stored_str: &str, incoming: &NameRef<'_>) -> bool {
   let stored_trim = match stored_str.strip_suffix('.') {
     Some(s) => s,
     None => stored_str,

--- a/mdns-proto/src/name.rs
+++ b/mdns-proto/src/name.rs
@@ -194,6 +194,61 @@ const _: () = {
       }
       Ok(Self(NameInner::from(buf)))
     }
+
+    /// Builds a canonical [`Name`] directly from a sequence of raw wire labels
+    /// (each the decompressed bytes of one DNS label, no length prefix),
+    /// joining them with `.` plus a trailing `.`. Labels are ASCII case-folded
+    /// (RFC 4343); non-ASCII bytes are preserved, and the assembled name must
+    /// be valid UTF-8 — DNS-SD names are UTF-8 (RFC 6763 §4.1). Returns `None`
+    /// on a malformed label (`Err` item), a label containing the `.` separator
+    /// byte, non-UTF-8 bytes, or a label/total length violation.
+    ///
+    /// This is the wire-decode counterpart to [`Name::try_from_str`]: it skips
+    /// the throwaway presentation `String` a caller would otherwise assemble
+    /// and — unlike a `byte as char` join — never Latin-1-reinterprets a
+    /// multi-byte UTF-8 sequence into mojibake.
+    ///
+    /// Length limits are checked incrementally, before each label is decoded or
+    /// pushed, so an oversized iterator is rejected without unbounded allocation.
+    pub fn from_wire_labels<'a, E, I>(labels: I) -> Option<Self>
+    where
+      I: IntoIterator<Item = Result<&'a [u8], E>>,
+    {
+      // `from_wire_labels` is public and accepts ANY iterator, so the length
+      // limits must be enforced incrementally, BEFORE decoding or pushing each
+      // label — otherwise a hostile caller could drive allocation proportional
+      // to the input for a name that is ultimately rejected (OOM). The bounded
+      // `NameRef::labels()` the endpoint passes always satisfies these, so this
+      // only rejects out-of-spec callers.
+      let mut buf = String::with_capacity(MAX_NAME_BYTES);
+      let mut wire_len: usize = 1; // terminating root label (RFC 1035 §3.1)
+      for label in labels {
+        let label = label.ok()?;
+        if label.len() > MAX_LABEL_BYTES as usize {
+          return None;
+        }
+        wire_len = wire_len.saturating_add(1).saturating_add(label.len());
+        if wire_len > MAX_NAME_BYTES {
+          return None;
+        }
+        // A wire label may legally carry a literal '.' byte, but `Name` joins
+        // labels with '.' as the separator — so a dot-bearing label would alias
+        // a different label sequence to the same string (["a.b","local"] would
+        // equal ["a","b","local"]) and poison cache identity (insert / TTL=0
+        // removal / cache-flush clamp all key on this `Name`). Reject it — the
+        // same contract the discovery layer enforces, since `Name` cannot
+        // represent a dot-bearing label faithfully.
+        if label.contains(&b'.') {
+          return None;
+        }
+        for ch in core::str::from_utf8(label).ok()?.chars() {
+          buf.push(ch.to_ascii_lowercase());
+        }
+        buf.push('.');
+      }
+      validate_name(&buf).ok()?;
+      Some(Self(NameInner::from(buf)))
+    }
   }
 };
 
@@ -215,6 +270,46 @@ const _: () = {
       }
       Ok(Self(buf))
     }
+
+    /// Builds a canonical [`Name`] directly from a sequence of raw wire labels
+    /// (each the decompressed bytes of one DNS label, no length prefix),
+    /// joining them with `.` plus a trailing `.`. Labels are ASCII case-folded
+    /// (RFC 4343); non-ASCII bytes are preserved, and the assembled name must
+    /// be valid UTF-8 — DNS-SD names are UTF-8 (RFC 6763 §4.1). Returns `None`
+    /// on a malformed label (`Err` item), non-UTF-8 bytes, or a label/total
+    /// length violation. Wire-decode counterpart to [`Name::try_from_str`].
+    pub fn from_wire_labels<'a, E, I>(labels: I) -> Option<Self>
+    where
+      I: IntoIterator<Item = Result<&'a [u8], E>>,
+    {
+      let mut buf: NameInner = heapless::String::new();
+      let mut wire_len: usize = 1; // terminating root label (RFC 1035 §3.1)
+      for label in labels {
+        let label = label.ok()?;
+        // Enforce the length limits before decoding (see the alloc/std path);
+        // the heapless buffer is already capped at MAX_NAME_BYTES, but this
+        // rejects an oversized label without scanning it first.
+        if label.len() > MAX_LABEL_BYTES as usize {
+          return None;
+        }
+        wire_len = wire_len.saturating_add(1).saturating_add(label.len());
+        if wire_len > MAX_NAME_BYTES {
+          return None;
+        }
+        // Reject a label carrying a literal '.' (see the alloc/std path): with
+        // '.' as the join separator a dot-bearing label would alias a different
+        // label sequence and poison cache identity.
+        if label.contains(&b'.') {
+          return None;
+        }
+        for ch in core::str::from_utf8(label).ok()?.chars() {
+          buf.push(ch.to_ascii_lowercase()).ok()?;
+        }
+        buf.push('.').ok()?;
+      }
+      validate_name(&buf).ok()?;
+      Some(Self(buf))
+    }
   }
 };
 
@@ -234,6 +329,57 @@ mod tests {
   fn canonical_lowercase_normalization() {
     let n = Name::try_from_str("My.Local.").unwrap();
     assert_eq!(n.as_str(), "my.local.");
+  }
+
+  #[test]
+  fn from_wire_labels_preserves_utf8_and_folds_ascii() {
+    // "Café" (é = U+00E9 → UTF-8 0xC3 0xA9). A `byte as char` join would
+    // Latin-1-double-encode the é; from_wire_labels keeps it intact while
+    // ASCII-folding the leading 'C'.
+    let labels: [Result<&[u8], core::convert::Infallible>; 2] = [Ok(b"Caf\xc3\xa9"), Ok(b"local")];
+    let n = Name::from_wire_labels(labels).unwrap();
+    assert_eq!(n.as_str(), "café.local.");
+  }
+
+  #[test]
+  fn from_wire_labels_rejects_non_utf8() {
+    let labels: [Result<&[u8], core::convert::Infallible>; 1] = [Ok(b"\xff\xfe")];
+    assert!(Name::from_wire_labels(labels).is_none());
+  }
+
+  #[test]
+  fn from_wire_labels_rejects_malformed_label() {
+    let labels: [Result<&[u8], &str>; 2] = [Ok(b"ok"), Err("truncated")];
+    assert!(Name::from_wire_labels(labels).is_none());
+  }
+
+  #[test]
+  fn from_wire_labels_rejects_dot_bearing_label_so_no_cache_aliasing() {
+    // A wire label may legally contain a literal '.' byte. Since `Name` joins
+    // labels with '.', a dot-bearing label MUST be rejected — otherwise
+    // ["a.b","local"] would alias ["a","b","local"] to the same cache key.
+    let dotted: [Result<&[u8], core::convert::Infallible>; 2] = [Ok(b"a.b"), Ok(b"local")];
+    assert!(Name::from_wire_labels(dotted).is_none());
+    let split: [Result<&[u8], core::convert::Infallible>; 3] = [Ok(b"a"), Ok(b"b"), Ok(b"local")];
+    assert_eq!(
+      Name::from_wire_labels(split).unwrap().as_str(),
+      "a.b.local."
+    );
+  }
+
+  #[test]
+  fn from_wire_labels_bounds_allocation_before_validation() {
+    // from_wire_labels is public, so it bounds work itself rather than trusting
+    // the caller (NameRef::labels already caps labels at 63 bytes). A label over
+    // MAX_LABEL_BYTES is rejected up front, before the name is assembled.
+    let long = [b'a'; 64];
+    let one: [Result<&[u8], core::convert::Infallible>; 1] = [Ok(&long[..])];
+    assert!(Name::from_wire_labels(one).is_none());
+    // An accumulated wire length over MAX_NAME_BYTES (here 10 x 63-byte labels)
+    // is rejected before the buffer can grow past the 255-octet limit.
+    let label = [b'a'; 63];
+    let many: [Result<&[u8], core::convert::Infallible>; 10] = [Ok(&label[..]); 10];
+    assert!(Name::from_wire_labels(many).is_none());
   }
 
   #[test]

--- a/mdns-proto/src/records.rs
+++ b/mdns-proto/src/records.rs
@@ -14,6 +14,23 @@ use std::vec::Vec;
 use crate::Name;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use bytes::Bytes;
+#[cfg(any(feature = "alloc", feature = "std"))]
+use std::sync::Arc;
+
+/// Append `item` to a read-only `Arc<[T]>`, returning a freshly sealed slice.
+/// `ServiceRecords`' collections are built incrementally via the `add_*`
+/// builders then frozen, so the O(n) reseal per append is paid only at build
+/// time (n is a handful of addresses / subtypes) — in exchange the derived
+/// `ServiceRecords::clone` is O(1) on the withdrawal-snapshot and rename-handoff
+/// paths, which previously deep-copied all five collections.
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn arc_push<T: Clone>(slice: &[T], item: T) -> Arc<[T]> {
+  slice
+    .iter()
+    .cloned()
+    .chain(core::iter::once(item))
+    .collect()
+}
 
 /// Records advertised by a single registered service.
 #[cfg(any(feature = "alloc", feature = "std"))]
@@ -29,8 +46,8 @@ pub struct ServiceRecords {
   port: u16,
   priority: u16,
   weight: u16,
-  a_addrs: Vec<Ipv4Addr>,
-  aaaa_addrs: Vec<Ipv6Addr>,
+  a_addrs: Arc<[Ipv4Addr]>,
+  aaaa_addrs: Arc<[Ipv6Addr]>,
   /// Parallel to `aaaa_addrs`: per-AAAA interface scope id (0 = "any").
   ///
   /// Used by [`Endpoint`](crate::endpoint::Endpoint) to disambiguate IPv6
@@ -39,14 +56,14 @@ pub struct ServiceRecords {
   /// the same link-local on a different interface would be wrongly
   /// classified as self.  Set via [`Self::add_aaaa_scoped`].  Always the
   /// same length as `aaaa_addrs`.
-  aaaa_scopes: Vec<u32>,
-  txt: Vec<Bytes>,
+  aaaa_scopes: Arc<[u32]>,
+  txt: Arc<[Bytes]>,
   /// RFC 6763 §7.1 subtype browse names, e.g. `_printer._sub._ipp._tcp.local.`.
   /// Each is the full `<sub>._sub.<service_type>` name (derived from
   /// `service_type` at [`Self::add_subtype`] time, so it survives an instance
   /// rename — the service type does not change). The service emits a shared PTR
   /// `<browse_name> -> instance` for each, and answers browse queries for them.
-  subtypes: Vec<Name>,
+  subtypes: Arc<[Name]>,
   ttl_secs: u32,
 }
 
@@ -65,11 +82,11 @@ impl ServiceRecords {
       port,
       priority: 0,
       weight: 0,
-      a_addrs: Vec::new(),
-      aaaa_addrs: Vec::new(),
-      aaaa_scopes: Vec::new(),
-      txt: Vec::new(),
-      subtypes: Vec::new(),
+      a_addrs: Arc::from([]),
+      aaaa_addrs: Arc::from([]),
+      aaaa_scopes: Arc::from([]),
+      txt: Arc::from([]),
+      subtypes: Arc::from([]),
       ttl_secs,
     }
   }
@@ -148,7 +165,7 @@ impl ServiceRecords {
 
   /// Append an IPv4 address.
   pub fn add_a(&mut self, addr: Ipv4Addr) -> &mut Self {
-    self.a_addrs.push(addr);
+    self.a_addrs = arc_push(&self.a_addrs, addr);
     self
   }
 
@@ -175,14 +192,14 @@ impl ServiceRecords {
   /// interface).  For global / unique-local IPv6 the scope is
   /// effectively ignored.
   pub fn add_aaaa_scoped(&mut self, addr: Ipv6Addr, scope_id: u32) -> &mut Self {
-    self.aaaa_addrs.push(addr);
-    self.aaaa_scopes.push(scope_id);
+    self.aaaa_addrs = arc_push(&self.aaaa_addrs, addr);
+    self.aaaa_scopes = arc_push(&self.aaaa_scopes, scope_id);
     self
   }
 
   /// Append a TXT segment.
   pub fn add_txt_segment(&mut self, segment: Vec<u8>) -> &mut Self {
-    self.txt.push(segment.into());
+    self.txt = arc_push(&self.txt, segment.into());
     self
   }
 
@@ -209,7 +226,7 @@ impl ServiceRecords {
       self.service_type.as_str()
     );
     let name = Name::try_from_str(&browse)?;
-    self.subtypes.push(name);
+    self.subtypes = arc_push(&self.subtypes, name);
     Ok(self)
   }
 


### PR DESCRIPTION
## Summary

An allocation / deep-clone reduction pass across `mdns-proto` and the three drivers, plus a correctness + hardening fix to inbound name decoding that surfaced during adversarial review.

### `fix(mdns-proto)` — inbound-name decode
- New `Name::from_wire_labels` (SmolStr + heapless backings) replaces an `endpoint.rs` cache-population loop that pushed each wire byte as `b as char` — a Latin-1 reinterpretation that double-encoded multi-byte UTF-8 (DNS-SD names are UTF-8, RFC 6763 §4.1). Correct now, and 3→2 allocs on the hottest recv path.
- Rejects labels containing a literal `.` — a dot-bearing wire label would otherwise alias a different label sequence to the same `Name` / cache key (a cache-poisoning vector the old loop also had).
- Enforces per-label + total wire-length limits incrementally, before decoding — the constructor is `pub`, so it bounds its own allocation rather than trusting the caller (OOM hardening).
- `is_meta_query_name` routes through a new `names_match_str`, dropping a per-question `Name` allocation.

### `perf` — Arc/Bytes + pump-loop scratch
- `ServiceRecords` write-once collections (`a_addrs` / `aaaa_addrs` / `aaaa_scopes` / `txt` / `subtypes`) → `Arc<[T]>`: O(1) clone on the withdrawal / rename paths; private fields, `_slice()` accessors unchanged.
- Driver discovery `ServiceEntry` → `Arc<[…]>` / `Bytes`; the `fold` lookup key uses `SmolStr::new` (no guaranteed-heap char-collect).
- `fire_timeouts` (all three drivers): per-tick `Vec<Handle>` snapshot removed via split-borrow / `values_mut()`.
- Transmit-pump loops (`poll_one_transmit` / `push_service_updates` / `drain_service_updates`): reuse persistent scratch buffers instead of a per-pump-call `Vec`.
