### PR TITLE
docs(changelog): document the hick v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
 # RELEASED
 
-## 0.1.0 (January 11st, 2025)
+## 0.1.0 (June 6th, 2026)
+
+First public release of the `hick` mDNS / DNS-SD family (the project formerly
+known as `agnostic-mdns`), rebuilt on a Sans-I/O protocol core with pluggable
+async drivers.
+
+Published crates: `hick` 0.1.0, `mdns-proto` 0.2.0, `hick-udp` 0.1.0,
+`hick-reactor` 0.1.0, `hick-compio` 0.1.0, `hick-smoltcp` 0.1.0,
+`hick-embassy` 0.1.0, `hick-trace` 0.1.0.
 
 FEATURES
 
-- Finish mdns implementation
-- Support `tokio`, `async-std` and `smol`
+- Sans-I/O mDNS / DNS-SD protocol core (`mdns-proto`), `no_std`-capable on
+  `alloc` or `heapless`, with a `#![forbid(unsafe_code)]` core.
+- Runtime-agnostic async drivers: `tokio` and `smol` via `hick-reactor`, and
+  `compio` (thread-per-core) via `hick-compio`.
+- Bare-metal drivers over smoltcp: `hick-smoltcp` (runtime-agnostic engine) and
+  `hick-embassy` (embassy-net async driver), both `no_std` + `alloc`.
+- RFC 6762 / 6763 conformance: probing and announcing, name-conflict detection
+  with automatic renaming, known-answer and duplicate-question suppression,
+  TTL-accurate caching, and TTL=0 goodbyes on withdrawal.
+- Multicast UDP socket layer (`hick-udp`) over rustix on unix and
+  socket2 + windows-sys on Windows.
+- Observability via `hick-trace`: opt-in `tracing`, `metrics`, `stats`, and
+  `defmt`.
+
+MSRV: Rust 1.91 (edition 2024). Licensed under MIT OR Apache-2.0.


### PR DESCRIPTION
Replaces the stale pre-rebrand `agnostic-mdns` 0.1.0 placeholder (listed `async-std`, never supported) with an accurate entry for the first public `hick` release — all 8 crates with their published versions, today's date — matching the [v0.1.0 GitHub release](https://github.com/al8n/hick/releases/tag/v0.1.0).