### PR TITLE
fix: treat IPv6 enumeration errors as errors, not absence

### DIFF
--- a/hick-compio/src/endpoint.rs
+++ b/hick-compio/src/endpoint.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::future::select_all;
 use hick_trace::*;
 use hick_udp::{
-  MulticastOptionsV4, MulticastOptionsV6,
+  Family, MulticastOptionsV4, MulticastOptionsV6,
   onlink::{collect_local_subnets, is_loopback_interface},
   try_bind_v4, try_bind_v6, try_join_v4, try_join_v6,
 };
@@ -53,27 +53,35 @@ impl Endpoint {
 
     let interface_index = match opts.interface_index() {
       Some(i) => i,
-      None => pick_default_interface_index(opts.ipv4(), opts.ipv6()).ok_or_else(|| {
-        ServerError::Io(io::Error::new(
-          ErrorKind::NotFound,
-          "no multicast-capable interface found",
-        ))
-      })?,
+      None => pick_default_interface_index(opts.ipv4(), opts.ipv6())
+        .map_err(ServerError::Io)?
+        .ok_or_else(|| {
+          ServerError::Io(io::Error::new(
+            ErrorKind::NotFound,
+            "no multicast-capable interface found",
+          ))
+        })?,
     };
 
-    // Gracefully degrade — if the chosen interface lacks one of the
-    // requested families, bind only the family it can support rather than
-    // failing the entire endpoint.
-    let iface_has_v4 = match getifs::interface_by_index(interface_index) {
-      Ok(Some(i)) => matches!(i.ipv4_addrs(), Ok(ref a) if !a.is_empty()),
-      _ => false,
+    // Ok(empty) degrades a family; Err is not absence — see has_addr_in.
+    let (bind_v4, bind_v6) = match getifs::interface_by_index(interface_index) {
+      Ok(Some(i)) => (
+        opts.ipv4() && has_addr_in(&i, Family::V4).map_err(ServerError::Io)?,
+        opts.ipv6() && has_addr_in(&i, Family::V6).map_err(ServerError::Io)?,
+      ),
+      Ok(None) => {
+        return Err(ServerError::Io(io::Error::new(
+          ErrorKind::NotFound,
+          format!("no interface with index {interface_index}"),
+        )));
+      }
+      Err(e) => {
+        return Err(ServerError::Io(io::Error::new(
+          e.kind(),
+          format!("looking up interface {interface_index}: {e}"),
+        )));
+      }
     };
-    let iface_has_v6 = match getifs::interface_by_index(interface_index) {
-      Ok(Some(i)) => matches!(i.ipv6_addrs(), Ok(ref a) if !a.is_empty()),
-      _ => false,
-    };
-    let bind_v4 = opts.ipv4() && iface_has_v4;
-    let bind_v6 = opts.ipv6() && iface_has_v6;
     if !bind_v4 && !bind_v6 {
       return Err(ServerError::Io(io::Error::new(
         ErrorKind::AddrNotAvailable,
@@ -400,39 +408,132 @@ impl Drop for Endpoint {
   }
 }
 
-/// Pick a default interface index when the caller didn't pin one. Mirrors
-/// the algorithm in `hick-reactor::endpoint::pick_default_interface_index`:
-/// prefer a non-loopback, multicast-up interface that satisfies every
-/// requested family; fall back through looser predicates ending at the
-/// loopback interface.
-fn pick_default_interface_index(want_v4: bool, want_v6: bool) -> Option<u32> {
-  let ifs = getifs::interfaces().ok()?;
-  let has_v4 = |i: &getifs::Interface| matches!(i.ipv4_addrs(), Ok(ref v) if !v.is_empty());
-  let has_v6 = |i: &getifs::Interface| matches!(i.ipv6_addrs(), Ok(ref v) if !v.is_empty());
-  let multicast_up_non_loopback = |i: &getifs::Interface| -> bool {
-    let f = i.flags();
-    f.contains(getifs::Flags::UP)
-      && f.contains(getifs::Flags::MULTICAST)
-      && !f.contains(getifs::Flags::LOOPBACK)
-      && i.index() != 0
+/// Pick a default interface index when the caller didn't pin one.
+///
+/// Dispatches to [`rank_candidates`], which probes a candidate's addresses only
+/// while its answer can still outrank the incumbent. An error is propagated
+/// when reading a candidate that could change the pick, preserving the rule
+/// that transient enumeration failures (e.g. `EINTR`) are hard errors and not
+/// mistaken for an absent family.
+fn pick_default_interface_index(want_v4: bool, want_v6: bool) -> io::Result<Option<u32>> {
+  let ifs = getifs::interfaces()
+    .map_err(|e| io::Error::new(e.kind(), format!("enumerating network interfaces: {e}")))?;
+  rank_candidates(
+    ifs
+      .iter()
+      .filter_map(|i| Some((tier_base(i)?, i.index(), i))),
+    want_v4,
+    want_v6,
+    |iface, family| has_addr_in(iface, family),
+  )
+}
+
+/// The best tier `iface`'s FLAGS alone can qualify it for, or `None` when they
+/// disqualify it outright.
+///
+/// Tier 0 is an up, multicast-capable, non-loopback interface and tier 2 is an
+/// up loopback one; each tier's odd neighbour above it is the same interface
+/// serving only some of the requested families. Reading no address here is what
+/// keeps an interface the picker would never choose from costing a syscall — or
+/// failing one.
+fn tier_base(iface: &getifs::Interface) -> Option<u8> {
+  let f = iface.flags();
+  if f.contains(getifs::Flags::UP)
+    && f.contains(getifs::Flags::MULTICAST)
+    && !f.contains(getifs::Flags::LOOPBACK)
+    && iface.index() != 0
+  {
+    Some(0)
+  } else if f.contains(getifs::Flags::LOOPBACK) && f.contains(getifs::Flags::UP) {
+    Some(2)
+  } else {
+    None
+  }
+}
+
+/// Rank already-classified candidates and return the winner's interface index.
+///
+/// `candidates` yields `(tier_base, index, subject)`, where `subject` is
+/// whatever `has_addr` needs to read that candidate's addresses.
+///
+/// One pass over four preference tiers, lowest wins, first-seen wins within a
+/// tier. Probes for a family only while its answer can still outrank the
+/// incumbent.
+fn rank_candidates<S>(
+  candidates: impl IntoIterator<Item = (u8, u32, S)>,
+  want_v4: bool,
+  want_v6: bool,
+  mut has_addr: impl FnMut(&S, Family) -> io::Result<bool>,
+) -> io::Result<Option<u32>> {
+  let mut best: Option<(u8, u32)> = None;
+  'candidates: for (tier_base, index, subject) in candidates {
+    let mut reachable = tier_base;
+    let mut serves_any = false;
+    for (family, wanted) in [(Family::V4, want_v4), (Family::V6, want_v6)] {
+      if best.is_some_and(|(seen, _)| reachable >= seen) {
+        continue 'candidates;
+      }
+      let serves = wanted && has_addr(&subject, family)?;
+      serves_any |= serves;
+      if wanted && !serves {
+        reachable = tier_base + 1;
+      }
+    }
+    if !serves_any && reachable > tier_base {
+      continue;
+    }
+    if best.is_none_or(|(seen, _)| reachable < seen) {
+      best = Some((reachable, index));
+    }
+  }
+  Ok(best.map(|(_, index)| index))
+}
+
+/// Address presence for `family`. `false` only means Ok(empty); Err is not absence.
+fn has_addr_in(iface: &getifs::Interface, family: Family) -> io::Result<bool> {
+  let index = iface.index();
+  let (label, addrs) = match family {
+    Family::V4 => ("IPv4", iface.ipv4_addrs().map(|a| !a.is_empty())),
+    Family::V6 => ("IPv6", iface.ipv6_addrs().map(|a| !a.is_empty())),
   };
-  let loopback_up = |i: &getifs::Interface| -> bool {
-    i.flags().contains(getifs::Flags::LOOPBACK) && i.flags().contains(getifs::Flags::UP)
+  #[cfg(test)]
+  let addrs = match forced_enumeration_error() {
+    Some(forced) if forced == family => Err(io::Error::from(ErrorKind::PermissionDenied)),
+    _ => addrs,
   };
-  let strict =
-    |i: &&getifs::Interface| -> bool { (!want_v4 || has_v4(i)) && (!want_v6 || has_v6(i)) };
-  let loose = |i: &&getifs::Interface| -> bool { (want_v4 && has_v4(i)) || (want_v6 && has_v6(i)) };
-  ifs
-    .iter()
-    .find(|i| multicast_up_non_loopback(i) && strict(i))
-    .or_else(|| {
-      ifs
-        .iter()
-        .find(|i| multicast_up_non_loopback(i) && loose(i))
-    })
-    .or_else(|| ifs.iter().find(|i| loopback_up(i) && strict(i)))
-    .or_else(|| ifs.iter().find(|i| loopback_up(i) && loose(i)))
-    .map(|i| i.index())
+  addrs.map_err(|e| {
+    io::Error::new(
+      e.kind(),
+      format!("reading the {label} addresses of interface {index}: {e}"),
+    )
+  })
+}
+
+#[cfg(test)]
+thread_local! {
+  static FORCED_ENUMERATION_ERROR: core::cell::Cell<Option<Family>> =
+    const { core::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn forced_enumeration_error() -> Option<Family> {
+  FORCED_ENUMERATION_ERROR.with(core::cell::Cell::get)
+}
+
+#[cfg(test)]
+fn force_enumeration_error_for_test(family: Family) -> ForcedEnumerationError {
+  FORCED_ENUMERATION_ERROR.with(|c| c.set(Some(family)));
+  ForcedEnumerationError
+}
+
+#[cfg(test)]
+struct ForcedEnumerationError;
+
+#[cfg(test)]
+impl Drop for ForcedEnumerationError {
+  fn drop(&mut self) {
+    FORCED_ENUMERATION_ERROR.with(|c| c.set(None));
+  }
 }
 
 #[cfg(test)]

--- a/hick-compio/src/endpoint/tests.rs
+++ b/hick-compio/src/endpoint/tests.rs
@@ -1,6 +1,6 @@
-use hick_udp::onlink::collect_local_subnets;
+use hick_udp::{Family, onlink::collect_local_subnets};
 
-use super::pick_default_interface_index;
+use super::{force_enumeration_error_for_test, has_addr_in, pick_default_interface_index};
 
 #[test]
 fn pick_default_interface_index_runs_for_every_family_combo() {
@@ -9,8 +9,255 @@ fn pick_default_interface_index_runs_for_every_family_combo() {
   // family combination yields an Option, and a returned index resolves to a
   // (possibly empty) subnet list.
   for (v4, v6) in [(true, true), (true, false), (false, true), (false, false)] {
-    if let Some(idx) = pick_default_interface_index(v4, v6) {
+    if let Some(idx) = pick_default_interface_index(v4, v6).expect("enumerating interfaces") {
       let _ = collect_local_subnets(idx);
     }
   }
+}
+
+#[test]
+fn the_default_interface_picker_reports_a_failed_address_enumeration() {
+  let Ok(ifs) = getifs::interfaces() else {
+    eprintln!("skipping: this host will not enumerate its interfaces at all");
+    return;
+  };
+  let qualifies = |i: &getifs::Interface| {
+    let f = i.flags();
+    f.contains(getifs::Flags::UP)
+      && (f.contains(getifs::Flags::LOOPBACK) || f.contains(getifs::Flags::MULTICAST))
+  };
+  if !ifs.iter().any(qualifies) {
+    eprintln!("skipping: no UP interface for the picker to consider");
+    return;
+  }
+  let _forced = force_enumeration_error_for_test(Family::V6);
+  let err = pick_default_interface_index(true, true).expect_err(
+    "a candidate whose addresses could not be read must not be ranked as if it had none",
+  );
+  assert_ne!(
+    err.kind(),
+    std::io::ErrorKind::NotFound,
+    "NotFound is the nothing-qualified answer; a failed read must not borrow it"
+  );
+  assert!(
+    err.to_string().contains("IPv6"),
+    "the message must name the family that could not be read, got {err}"
+  );
+}
+
+#[test]
+fn a_failed_address_enumeration_is_not_a_missing_address() {
+  let Some(idx) = getifs::interfaces().ok().and_then(|ifs| {
+    ifs
+      .into_iter()
+      .find(|i| i.flags().contains(getifs::Flags::UP))
+      .map(|i| i.index())
+  }) else {
+    eprintln!("skipping: no UP interface reported by getifs");
+    return;
+  };
+  let iface = getifs::interface_by_index(idx)
+    .expect("looking up an UP interface")
+    .expect("the index just read back must name an interface");
+  {
+    let _forced = force_enumeration_error_for_test(Family::V6);
+    assert!(
+      has_addr_in(&iface, Family::V4).is_ok(),
+      "forcing IPv6 to fail must leave the IPv4 probe alone"
+    );
+    let err = has_addr_in(&iface, Family::V6).expect_err("forced IPv6 read must fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_ne!(err.kind(), std::io::ErrorKind::AddrNotAvailable);
+    assert!(
+      err.to_string().contains("IPv6") && err.to_string().contains(&idx.to_string()),
+      "the message must name the family and interface, got {err}"
+    );
+  }
+  assert!(
+    has_addr_in(&iface, Family::V6).is_ok(),
+    "the guard must disarm the injection"
+  );
+}
+
+fn probe_failing<'a>(
+  failing: &'static str,
+  asked: &'a mut Vec<(&'static str, Family)>,
+) -> impl FnMut(&&'static str, Family) -> std::io::Result<bool> + 'a {
+  move |name, family| {
+    asked.push((name, family));
+    if *name == failing {
+      return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+    }
+    Ok(true)
+  }
+}
+
+#[test]
+fn a_failure_in_a_family_nobody_requested_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates([(0, 7, "eth0")], true, false, |name, family| {
+    asked.push((*name, family));
+    match family {
+      Family::V6 => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      Family::V4 => Ok(true),
+    }
+  });
+  assert_eq!(
+    picked.expect("an IPv6 read the caller never asked for cannot fail an IPv4-only pick"),
+    Some(7)
+  );
+  assert_eq!(
+    asked,
+    vec![("eth0", Family::V4)],
+    "a family that was not requested must not be probed at all: the short \
+     circuit is what makes the failure unreachable rather than merely ignored"
+  );
+}
+
+#[test]
+fn a_failure_after_an_unbeatable_candidate_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(0, 7, "eth0"), (0, 8, "eth1")],
+    true,
+    true,
+    probe_failing("eth1", &mut asked),
+  );
+  assert_eq!(
+    picked.expect("nothing can outrank a tier-0 winner, so nothing after it may fail the pick"),
+    Some(7),
+    "first-seen-wins within a tier: the incumbent keeps the pick"
+  );
+  assert_eq!(
+    asked,
+    vec![("eth0", Family::V4), ("eth0", Family::V6)],
+    "a candidate that cannot beat the incumbent must not be probed, or a failure \
+     with no bearing on the answer is back to aborting the bind"
+  );
+}
+
+#[test]
+fn a_failure_on_a_candidate_that_could_outrank_the_winner_still_surfaces() {
+  let mut asked = Vec::new();
+  let err = super::rank_candidates(
+    [(2, 1, "lo"), (0, 8, "eth0")],
+    true,
+    true,
+    probe_failing("eth0", &mut asked),
+  )
+  .expect_err(
+    "a candidate that could outrank the winner must not be ranked on an answer \
+     nobody obtained: that binds the wrong link and looks like a working \
+     responder until nothing is ever discovered",
+  );
+  assert_eq!(
+    err.kind(),
+    std::io::ErrorKind::PermissionDenied,
+    "the platform's own kind must be carried over, not flattened, got {err:?}"
+  );
+  assert!(
+    asked.contains(&("eth0", Family::V4)),
+    "the higher-ranked candidate must actually have been probed"
+  );
+}
+
+#[test]
+fn a_failure_after_the_first_probe_cost_the_strict_tier_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(0, 7, "eth0"), (0, 8, "eth1")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("eth0", Family::V4) => Ok(true),
+        ("eth0", Family::V6) => Ok(false),
+        ("eth1", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  );
+  assert_eq!(
+    picked.expect(
+      "a probe whose answer can no longer beat the incumbent must not be made, let alone \
+       abort the pick"
+    ),
+    Some(7),
+    "first-seen-wins within a tier: the incumbent keeps the pick"
+  );
+  assert_eq!(
+    asked,
+    vec![
+      ("eth0", Family::V4),
+      ("eth0", Family::V6),
+      ("eth1", Family::V4)
+    ],
+    "the tier a candidate can still reach is re-weighed between its own probes, not just \
+     before the first"
+  );
+}
+
+#[test]
+fn the_tier_a_probe_is_weighed_against_is_the_candidates_own() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(2, 1, "lo0"), (2, 9, "lo1")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("lo0", Family::V4) => Ok(true),
+        ("lo0", Family::V6) => Ok(false),
+        ("lo1", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  );
+  assert_eq!(
+    picked.expect(
+      "a tier-3 incumbent is no more beatable by a second tier-3 candidate than a tier-1 \
+       one is"
+    ),
+    Some(1)
+  );
+  assert_eq!(
+    asked,
+    vec![
+      ("lo0", Family::V4),
+      ("lo0", Family::V6),
+      ("lo1", Family::V4)
+    ],
+    "the loose tier a failed family leaves within reach is relative to the candidate's own \
+     base, so the second probe must be skipped here too"
+  );
+}
+
+#[test]
+fn a_failure_after_a_first_probe_that_left_the_pick_in_reach_still_surfaces() {
+  let mut asked = Vec::new();
+  let err = super::rank_candidates(
+    [(2, 1, "lo"), (0, 8, "eth0")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("lo", Family::V4) => Ok(true),
+        ("lo", Family::V6) => Ok(false),
+        ("eth0", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  )
+  .expect_err(
+    "skipping a probe is sound only while its answer cannot matter; here it decides the \
+     pick, and ranking the candidate as having no IPv6 address binds a link nobody read",
+  );
+  assert_eq!(
+    err.kind(),
+    std::io::ErrorKind::PermissionDenied,
+    "the platform's own kind must be carried over, not flattened, got {err:?}"
+  );
 }

--- a/hick-reactor/src/endpoint.rs
+++ b/hick-reactor/src/endpoint.rs
@@ -5,7 +5,8 @@ use std::future::Future;
 use agnostic_net::Net;
 use async_channel::Sender;
 use hick_udp::{
-  MulticastOptionsV4, MulticastOptionsV6, try_bind_v4, try_bind_v6, try_join_v4, try_join_v6,
+  Family, MulticastOptionsV4, MulticastOptionsV6, try_bind_v4, try_bind_v6, try_join_v4,
+  try_join_v6,
 };
 use mdns_proto::{QuerySpec, ServiceSpec};
 
@@ -83,30 +84,35 @@ impl Endpoint {
 
     let interface_index = match opts.interface_index() {
       Some(i) => i,
-      None => pick_default_interface_index(opts.ipv4(), opts.ipv6()).ok_or_else(|| {
-        ServerError::Io(std::io::Error::new(
-          std::io::ErrorKind::NotFound,
-          "no multicast-capable interface found",
-        ))
-      })?,
+      None => pick_default_interface_index(opts.ipv4(), opts.ipv6())
+        .map_err(ServerError::Io)?
+        .ok_or_else(|| {
+          ServerError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no multicast-capable interface found",
+          ))
+        })?,
     };
 
-    // gracefully degrade — if the chosen interface lacks one of
-    // the requested families, bind only the family it can support rather
-    // than failing the entire endpoint. This makes
-    // `with_ipv4(true).with_ipv6(true)` work on hosts with no global v6
-    // (the common single-stack case) while still honouring an explicit
-    // single-family request.
-    let iface_has_v4 = match getifs::interface_by_index(interface_index) {
-      Ok(Some(i)) => matches!(i.ipv4_addrs(), Ok(ref a) if !a.is_empty()),
-      _ => false,
+    // Ok(empty) degrades a family; Err is not absence — see has_addr_in.
+    let (bind_v4, bind_v6) = match getifs::interface_by_index(interface_index) {
+      Ok(Some(i)) => (
+        opts.ipv4() && has_addr_in(&i, Family::V4).map_err(ServerError::Io)?,
+        opts.ipv6() && has_addr_in(&i, Family::V6).map_err(ServerError::Io)?,
+      ),
+      Ok(None) => {
+        return Err(ServerError::Io(std::io::Error::new(
+          std::io::ErrorKind::NotFound,
+          format!("no interface with index {interface_index}"),
+        )));
+      }
+      Err(e) => {
+        return Err(ServerError::Io(std::io::Error::new(
+          e.kind(),
+          format!("looking up interface {interface_index}: {e}"),
+        )));
+      }
     };
-    let iface_has_v6 = match getifs::interface_by_index(interface_index) {
-      Ok(Some(i)) => matches!(i.ipv6_addrs(), Ok(ref a) if !a.is_empty()),
-      _ => false,
-    };
-    let bind_v4 = opts.ipv4() && iface_has_v4;
-    let bind_v6 = opts.ipv6() && iface_has_v6;
     if !bind_v4 && !bind_v6 {
       return Err(ServerError::Io(std::io::Error::new(
         std::io::ErrorKind::AddrNotAvailable,
@@ -317,41 +323,134 @@ fn map_join_to_bind_v6(e: hick_udp::JoinError) -> ServerError {
   }
 }
 
-fn pick_default_interface_index(want_v4: bool, want_v6: bool) -> Option<u32> {
-  let ifs = getifs::interfaces().ok()?;
-  let has_v4 = |i: &getifs::Interface| matches!(i.ipv4_addrs(), Ok(ref v) if !v.is_empty());
-  let has_v6 = |i: &getifs::Interface| matches!(i.ipv6_addrs(), Ok(ref v) if !v.is_empty());
-  let multicast_up_non_loopback = |i: &getifs::Interface| -> bool {
-    let f = i.flags();
-    f.contains(getifs::Flags::UP)
-      && f.contains(getifs::Flags::MULTICAST)
-      && !f.contains(getifs::Flags::LOOPBACK)
-      && i.index() != 0
+/// Pick a default interface index when the caller didn't pin one.
+///
+/// Dispatches to [`rank_candidates`], which probes a candidate's addresses only
+/// while its answer can still outrank the incumbent. An error is propagated
+/// when reading a candidate that could change the pick, preserving the rule
+/// that transient enumeration failures (e.g. `EINTR`) are hard errors and not
+/// mistaken for an absent family.
+fn pick_default_interface_index(want_v4: bool, want_v6: bool) -> std::io::Result<Option<u32>> {
+  let ifs = getifs::interfaces()
+    .map_err(|e| std::io::Error::new(e.kind(), format!("enumerating network interfaces: {e}")))?;
+  rank_candidates(
+    ifs
+      .iter()
+      .filter_map(|i| Some((tier_base(i)?, i.index(), i))),
+    want_v4,
+    want_v6,
+    |iface, family| has_addr_in(iface, family),
+  )
+}
+
+/// The best tier `iface`'s FLAGS alone can qualify it for, or `None` when they
+/// disqualify it outright.
+///
+/// Tier 0 is an up, multicast-capable, non-loopback interface and tier 2 is an
+/// up loopback one; each tier's odd neighbour above it is the same interface
+/// serving only some of the requested families. Reading no address here is what
+/// keeps an interface the picker would never choose from costing a syscall — or
+/// failing one.
+fn tier_base(iface: &getifs::Interface) -> Option<u8> {
+  let f = iface.flags();
+  if f.contains(getifs::Flags::UP)
+    && f.contains(getifs::Flags::MULTICAST)
+    && !f.contains(getifs::Flags::LOOPBACK)
+    && iface.index() != 0
+  {
+    Some(0)
+  } else if f.contains(getifs::Flags::LOOPBACK) && f.contains(getifs::Flags::UP) {
+    Some(2)
+  } else {
+    None
+  }
+}
+
+/// Rank already-classified candidates and return the winner's interface index.
+///
+/// `candidates` yields `(tier_base, index, subject)`, where `subject` is
+/// whatever `has_addr` needs to read that candidate's addresses.
+///
+/// One pass over four preference tiers, lowest wins, first-seen wins within a
+/// tier. Probes for a family only while its answer can still outrank the
+/// incumbent.
+fn rank_candidates<S>(
+  candidates: impl IntoIterator<Item = (u8, u32, S)>,
+  want_v4: bool,
+  want_v6: bool,
+  mut has_addr: impl FnMut(&S, Family) -> std::io::Result<bool>,
+) -> std::io::Result<Option<u32>> {
+  let mut best: Option<(u8, u32)> = None;
+  'candidates: for (tier_base, index, subject) in candidates {
+    let mut reachable = tier_base;
+    let mut serves_any = false;
+    for (family, wanted) in [(Family::V4, want_v4), (Family::V6, want_v6)] {
+      if best.is_some_and(|(seen, _)| reachable >= seen) {
+        continue 'candidates;
+      }
+      let serves = wanted && has_addr(&subject, family)?;
+      serves_any |= serves;
+      if wanted && !serves {
+        reachable = tier_base + 1;
+      }
+    }
+    if !serves_any && reachable > tier_base {
+      continue;
+    }
+    if best.is_none_or(|(seen, _)| reachable < seen) {
+      best = Some((reachable, index));
+    }
+  }
+  Ok(best.map(|(_, index)| index))
+}
+
+/// Address presence for `family`. `false` only means Ok(empty); Err is not absence.
+fn has_addr_in(iface: &getifs::Interface, family: Family) -> std::io::Result<bool> {
+  let index = iface.index();
+  let (label, addrs) = match family {
+    Family::V4 => ("IPv4", iface.ipv4_addrs().map(|a| !a.is_empty())),
+    Family::V6 => ("IPv6", iface.ipv6_addrs().map(|a| !a.is_empty())),
   };
-  let loopback_up = |i: &getifs::Interface| -> bool {
-    i.flags().contains(getifs::Flags::LOOPBACK) && i.flags().contains(getifs::Flags::UP)
+  #[cfg(test)]
+  let addrs = match forced_enumeration_error() {
+    Some(forced) if forced == family => {
+      Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+    }
+    _ => addrs,
   };
-  // prefer an interface that satisfies ALL requested families;
-  // fall back to one that satisfies at least one. Without the loose fallback
-  // an IPv4-only NIC on a host with no global IPv6 would be silently
-  // rejected even though it can serve `with_ipv4(true).with_ipv6(true)` over
-  // v4 perfectly well.
-  let strict =
-    |i: &&getifs::Interface| -> bool { (!want_v4 || has_v4(i)) && (!want_v6 || has_v6(i)) };
-  let loose = |i: &&getifs::Interface| -> bool { (want_v4 && has_v4(i)) || (want_v6 && has_v6(i)) };
-  let strict_non_loopback = ifs
-    .iter()
-    .find(|i| multicast_up_non_loopback(i) && strict(i));
-  let loose_non_loopback = ifs
-    .iter()
-    .find(|i| multicast_up_non_loopback(i) && loose(i));
-  let strict_loopback = ifs.iter().find(|i| loopback_up(i) && strict(i));
-  let loose_loopback = ifs.iter().find(|i| loopback_up(i) && loose(i));
-  strict_non_loopback
-    .or(loose_non_loopback)
-    .or(strict_loopback)
-    .or(loose_loopback)
-    .map(|i| i.index())
+  addrs.map_err(|e| {
+    std::io::Error::new(
+      e.kind(),
+      format!("reading the {label} addresses of interface {index}: {e}"),
+    )
+  })
+}
+
+#[cfg(test)]
+thread_local! {
+  static FORCED_ENUMERATION_ERROR: core::cell::Cell<Option<Family>> =
+    const { core::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn forced_enumeration_error() -> Option<Family> {
+  FORCED_ENUMERATION_ERROR.with(core::cell::Cell::get)
+}
+
+#[cfg(test)]
+fn force_enumeration_error_for_test(family: Family) -> ForcedEnumerationError {
+  FORCED_ENUMERATION_ERROR.with(|c| c.set(Some(family)));
+  ForcedEnumerationError
+}
+
+#[cfg(test)]
+struct ForcedEnumerationError;
+
+#[cfg(test)]
+impl Drop for ForcedEnumerationError {
+  fn drop(&mut self) {
+    FORCED_ENUMERATION_ERROR.with(|c| c.set(None));
+  }
 }
 
 #[cfg(test)]

--- a/hick-reactor/src/endpoint/tests.rs
+++ b/hick-reactor/src/endpoint/tests.rs
@@ -1,4 +1,9 @@
-use super::{map_join_to_bind_v4, map_join_to_bind_v6};
+use hick_udp::{Family, onlink::collect_local_subnets};
+
+use super::{
+  force_enumeration_error_for_test, has_addr_in, map_join_to_bind_v4, map_join_to_bind_v6,
+  pick_default_interface_index,
+};
 use crate::error::ServerError;
 
 /// A join I/O failure is surfaced as the matching family's bind I/O error —
@@ -15,4 +20,264 @@ fn join_io_error_maps_to_family_bind_io_error() {
     v6,
     ServerError::BindV6(hick_udp::BindError::Io(_))
   ));
+}
+
+#[test]
+fn pick_default_interface_index_runs_for_every_family_combo() {
+  // Exercises the strict/loose, non-loopback/loopback fallback chain. The
+  // chosen index is environment dependent, so only the shape is asserted: any
+  // family combination yields an Option, and a returned index resolves to a
+  // (possibly empty) subnet list.
+  for (v4, v6) in [(true, true), (true, false), (false, true), (false, false)] {
+    if let Some(idx) = pick_default_interface_index(v4, v6).expect("enumerating interfaces") {
+      let _ = collect_local_subnets(idx);
+    }
+  }
+}
+
+#[test]
+fn the_default_interface_picker_reports_a_failed_address_enumeration() {
+  let Ok(ifs) = getifs::interfaces() else {
+    eprintln!("skipping: this host will not enumerate its interfaces at all");
+    return;
+  };
+  let qualifies = |i: &getifs::Interface| {
+    let f = i.flags();
+    f.contains(getifs::Flags::UP)
+      && (f.contains(getifs::Flags::LOOPBACK) || f.contains(getifs::Flags::MULTICAST))
+  };
+  if !ifs.iter().any(qualifies) {
+    eprintln!("skipping: no UP interface for the picker to consider");
+    return;
+  }
+  let _forced = force_enumeration_error_for_test(Family::V6);
+  let err = pick_default_interface_index(true, true).expect_err(
+    "a candidate whose addresses could not be read must not be ranked as if it had none",
+  );
+  assert_ne!(
+    err.kind(),
+    std::io::ErrorKind::NotFound,
+    "NotFound is the nothing-qualified answer; a failed read must not borrow it"
+  );
+  assert!(
+    err.to_string().contains("IPv6"),
+    "the message must name the family that could not be read, got {err}"
+  );
+}
+
+#[test]
+fn a_failed_address_enumeration_is_not_a_missing_address() {
+  let Some(idx) = getifs::interfaces().ok().and_then(|ifs| {
+    ifs
+      .into_iter()
+      .find(|i| i.flags().contains(getifs::Flags::UP))
+      .map(|i| i.index())
+  }) else {
+    eprintln!("skipping: no UP interface reported by getifs");
+    return;
+  };
+  let iface = getifs::interface_by_index(idx)
+    .expect("looking up an UP interface")
+    .expect("the index just read back must name an interface");
+  {
+    let _forced = force_enumeration_error_for_test(Family::V6);
+    assert!(
+      has_addr_in(&iface, Family::V4).is_ok(),
+      "forcing IPv6 to fail must leave the IPv4 probe alone"
+    );
+    let err = has_addr_in(&iface, Family::V6).expect_err("forced IPv6 read must fail");
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_ne!(err.kind(), std::io::ErrorKind::AddrNotAvailable);
+    assert!(
+      err.to_string().contains("IPv6") && err.to_string().contains(&idx.to_string()),
+      "the message must name the family and interface, got {err}"
+    );
+  }
+  assert!(
+    has_addr_in(&iface, Family::V6).is_ok(),
+    "the guard must disarm the injection"
+  );
+}
+
+fn probe_failing<'a>(
+  failing: &'static str,
+  asked: &'a mut Vec<(&'static str, Family)>,
+) -> impl FnMut(&&'static str, Family) -> std::io::Result<bool> + 'a {
+  move |name, family| {
+    asked.push((name, family));
+    if *name == failing {
+      return Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+    }
+    Ok(true)
+  }
+}
+
+#[test]
+fn a_failure_in_a_family_nobody_requested_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates([(0, 7, "eth0")], true, false, |name, family| {
+    asked.push((*name, family));
+    match family {
+      Family::V6 => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      Family::V4 => Ok(true),
+    }
+  });
+  assert_eq!(
+    picked.expect("an IPv6 read the caller never asked for cannot fail an IPv4-only pick"),
+    Some(7)
+  );
+  assert_eq!(
+    asked,
+    vec![("eth0", Family::V4)],
+    "a family that was not requested must not be probed at all: the short \
+     circuit is what makes the failure unreachable rather than merely ignored"
+  );
+}
+
+#[test]
+fn a_failure_after_an_unbeatable_candidate_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(0, 7, "eth0"), (0, 8, "eth1")],
+    true,
+    true,
+    probe_failing("eth1", &mut asked),
+  );
+  assert_eq!(
+    picked.expect("nothing can outrank a tier-0 winner, so nothing after it may fail the pick"),
+    Some(7),
+    "first-seen-wins within a tier: the incumbent keeps the pick"
+  );
+  assert_eq!(
+    asked,
+    vec![("eth0", Family::V4), ("eth0", Family::V6)],
+    "a candidate that cannot beat the incumbent must not be probed, or a failure \
+     with no bearing on the answer is back to aborting the bind"
+  );
+}
+
+#[test]
+fn a_failure_on_a_candidate_that_could_outrank_the_winner_still_surfaces() {
+  let mut asked = Vec::new();
+  let err = super::rank_candidates(
+    [(2, 1, "lo"), (0, 8, "eth0")],
+    true,
+    true,
+    probe_failing("eth0", &mut asked),
+  )
+  .expect_err(
+    "a candidate that could outrank the winner must not be ranked on an answer \
+     nobody obtained: that binds the wrong link and looks like a working \
+     responder until nothing is ever discovered",
+  );
+  assert_eq!(
+    err.kind(),
+    std::io::ErrorKind::PermissionDenied,
+    "the platform's own kind must be carried over, not flattened, got {err:?}"
+  );
+  assert!(
+    asked.contains(&("eth0", Family::V4)),
+    "the higher-ranked candidate must actually have been probed"
+  );
+}
+
+#[test]
+fn a_failure_after_the_first_probe_cost_the_strict_tier_does_not_fail_the_pick() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(0, 7, "eth0"), (0, 8, "eth1")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("eth0", Family::V4) => Ok(true),
+        ("eth0", Family::V6) => Ok(false),
+        ("eth1", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  );
+  assert_eq!(
+    picked.expect(
+      "a probe whose answer can no longer beat the incumbent must not be made, let alone \
+       abort the pick"
+    ),
+    Some(7),
+    "first-seen-wins within a tier: the incumbent keeps the pick"
+  );
+  assert_eq!(
+    asked,
+    vec![
+      ("eth0", Family::V4),
+      ("eth0", Family::V6),
+      ("eth1", Family::V4)
+    ],
+    "the tier a candidate can still reach is re-weighed between its own probes, not just \
+     before the first"
+  );
+}
+
+#[test]
+fn the_tier_a_probe_is_weighed_against_is_the_candidates_own() {
+  let mut asked = Vec::new();
+  let picked = super::rank_candidates(
+    [(2, 1, "lo0"), (2, 9, "lo1")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("lo0", Family::V4) => Ok(true),
+        ("lo0", Family::V6) => Ok(false),
+        ("lo1", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  );
+  assert_eq!(
+    picked.expect(
+      "a tier-3 incumbent is no more beatable by a second tier-3 candidate than a tier-1 \
+       one is"
+    ),
+    Some(1)
+  );
+  assert_eq!(
+    asked,
+    vec![
+      ("lo0", Family::V4),
+      ("lo0", Family::V6),
+      ("lo1", Family::V4)
+    ],
+    "the loose tier a failed family leaves within reach is relative to the candidate's own \
+     base, so the second probe must be skipped here too"
+  );
+}
+
+#[test]
+fn a_failure_after_a_first_probe_that_left_the_pick_in_reach_still_surfaces() {
+  let mut asked = Vec::new();
+  let err = super::rank_candidates(
+    [(2, 1, "lo"), (0, 8, "eth0")],
+    true,
+    true,
+    |name, family| {
+      asked.push((*name, family));
+      match (*name, family) {
+        ("lo", Family::V4) => Ok(true),
+        ("lo", Family::V6) => Ok(false),
+        ("eth0", Family::V4) => Ok(false),
+        _ => Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+      }
+    },
+  )
+  .expect_err(
+    "skipping a probe is sound only while its answer cannot matter; here it decides the \
+     pick, and ranking the candidate as having no IPv6 address binds a link nobody read",
+  );
+  assert_eq!(
+    err.kind(),
+    std::io::ErrorKind::PermissionDenied,
+    "the platform's own kind must be carried over, not flattened, got {err:?}"
+  );
 }


### PR DESCRIPTION
## Description

Fixes #103.

`getifs` address enumeration can fail with `EINTR` when DHCP, VPN, or interface churn interrupts a dump. `hick-compio` and `hick-reactor` treated that `Err` as "this interface has no IPv6" by folding it into `false`. That is a negative claim the evidence does not support: the same confusion `hick-mio`'s `has_addr_in` was rebuilt to prohibit.

`Ok(empty)` still degrades a requested family so dual-stack binds work on IPv4-only hosts. A failed read now fails the bind or default-interface picker instead of ranking the wrong link.

## Changes

- `hick-compio/src/endpoint.rs` and `hick-reactor/src/endpoint.rs`: port the `has_addr_in` three-state rule into bind and `pick_default_interface_index`.
- Matching unit tests inject an enumeration failure and assert it is reported as `Err`, not as a missing address.

## Verification

- `cargo test -p hick-compio --lib endpoint`
- `cargo test -p hick-reactor --lib endpoint`
